### PR TITLE
Add height-based coinbase maturity

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -591,6 +591,7 @@ add_library(bitcoinconsensus
 	uint256.cpp
 	util/strencodings.cpp
 	consensus/amount.cpp
+	consensus/consensus.cpp
 	consensus/tx_check.cpp
 )
 
@@ -871,6 +872,7 @@ if(BUILD_BITCOIN_CHAINSTATE)
 		config.cpp
 		consensus/activation.cpp
 		consensus/amount.cpp
+		consensus/consensus.cpp
 		consensus/merkle.cpp
 		consensus/tx_check.cpp
 		consensus/tx_verify.cpp

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -29,13 +29,13 @@ static void AssembleBlock(benchmark::Bench &bench) {
     // Collect some loose transactions that spend the coinbases of our mined
     // blocks
     constexpr size_t NUM_BLOCKS{200};
-    std::array<CTransactionRef, NUM_BLOCKS - COINBASE_MATURITY + 1> txs;
+    std::array<CTransactionRef, NUM_BLOCKS - REGTEST_COINBASE_MATURITY + 1> txs;
     for (size_t b = 0; b < NUM_BLOCKS; ++b) {
         CMutableTransaction tx;
         tx.vin.push_back(MineBlock(config, test_setup->m_node, SCRIPT_PUB));
         tx.vin.back().scriptSig = scriptSig;
         tx.vout.emplace_back(1337 * SATOSHI, SCRIPT_PUB);
-        if (NUM_BLOCKS - b >= COINBASE_MATURITY) {
+        if (NUM_BLOCKS - b >= REGTEST_COINBASE_MATURITY) {
             txs.at(b) = MakeTransactionRef(tx);
         }
     }

--- a/src/bench/chained_tx.cpp
+++ b/src/bench/chained_tx.cpp
@@ -43,7 +43,7 @@ static std::vector<CTxIn> createUTXOs(const Config &config, size_t n,
         utxos.emplace_back(MineBlock(config, node, SCRIPT_PUB_KEY));
     }
 
-    for (size_t i = 0; i < COINBASE_MATURITY + 1; ++i) {
+    for (size_t i = 0; i < REGTEST_COINBASE_MATURITY + 1; ++i) {
         MineBlock(config, node, SCRIPT_PUB_KEY);
     }
 

--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -128,3 +128,7 @@ bool IsAugustoEnabled(const Consensus::Params &params,
 
     return IsAugustoEnabled(params, pindexPrev->GetMedianTimePast());
 }
+
+bool IsDigishieldEnabled(const Consensus::Params &params, int32_t nHeight) {
+    return nHeight >= params.digishieldHeight;
+}

--- a/src/consensus/activation.h
+++ b/src/consensus/activation.h
@@ -57,4 +57,7 @@ bool IsAugustoEnabled(const Consensus::Params &params, int64_t nMedianTimePast);
 bool IsAugustoEnabled(const Consensus::Params &params,
                       const CBlockIndex *pindexPrev);
 
+/** Check if Dogecoin Digishield protocol upgrade has activated. */
+bool IsDigishieldEnabled(const Consensus::Params &params, int32_t nHeight);
+
 #endif // BITCOIN_CONSENSUS_ACTIVATION_H

--- a/src/consensus/consensus.cpp
+++ b/src/consensus/consensus.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/activation.h>
+#include <consensus/consensus.h>
+
+#include <consensus/params.h>
+
+int32_t CoinbaseMaturity(const Consensus::Params &params, int32_t nHeight) {
+    if (IsDigishieldEnabled(params, nHeight)) {
+        return DIGISHIELD_COINBASE_MATURITY;
+    }
+
+    return params.initialCoinbaseMaturity;
+}

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -8,6 +8,10 @@
 
 #include <cstdint>
 
+namespace Consensus {
+struct Params;
+}
+
 /** 1MB */
 static const uint64_t ONE_MEGABYTE = 1000000;
 /** The maximum allowed size for a transaction, in bytes */
@@ -29,7 +33,8 @@ static const int BLOCK_MAXBYTES_MAXSIGCHECKS_RATIO = 141;
  * Coinbase transaction outputs can only be spent after this number of new
  * blocks (network rule).
  */
-static const int COINBASE_MATURITY = 100;
+static const int REGTEST_COINBASE_MATURITY = 100;
+static const int DIGISHIELD_COINBASE_MATURITY = 240;
 /** Coinbase scripts have their own script size limit. */
 static const int MAX_COINBASE_SCRIPTSIG_SIZE = 100;
 
@@ -47,5 +52,7 @@ static constexpr unsigned int LOCKTIME_VERIFY_SEQUENCE = (1 << 0);
 inline uint64_t GetMaxBlockSigChecksCount(uint64_t maxBlockSize) {
     return maxBlockSize / BLOCK_MAXBYTES_MAXSIGCHECKS_RATIO;
 }
+
+int32_t CoinbaseMaturity(const Consensus::Params &params, int32_t nHeight);
 
 #endif // BITCOIN_CONSENSUS_CONSENSUS_H

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -64,6 +64,12 @@ struct Params {
     /** Unix time used for MTP activation of 15 Nov 2024 12:00:00 UTC upgrade */
     int augustoActivationTime;
 
+    /** Dogecoin "Digishield" activation height */
+    int digishieldHeight;
+
+    /** Coinbase maturity before Digishield */
+    int32_t initialCoinbaseMaturity;
+
     /** Enable or disable the miner fund by default */
     bool enableMinerFund;
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -167,7 +167,7 @@ bool SequenceLocks(const CTransaction &tx, int flags,
 namespace Consensus {
 bool CheckTxInputs(const CTransaction &tx, TxValidationState &state,
                    const CCoinsViewCache &inputs, int nSpendHeight,
-                   Amount &txfee) {
+                   Amount &txfee, const Consensus::Params &params) {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
         return state.Invalid(TxValidationResult::TX_MISSING_INPUTS,
@@ -182,8 +182,8 @@ bool CheckTxInputs(const CTransaction &tx, TxValidationState &state,
         assert(!coin.IsSpent());
 
         // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase() &&
-            nSpendHeight - coin.GetHeight() < COINBASE_MATURITY) {
+        if (coin.IsCoinBase() && nSpendHeight - (int)coin.GetHeight() <
+                                     CoinbaseMaturity(params, nSpendHeight)) {
             return state.Invalid(
                 TxValidationResult::TX_PREMATURE_SPEND,
                 "bad-txns-premature-spend-of-coinbase",

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -26,7 +26,7 @@ struct Params;
  */
 bool CheckTxInputs(const CTransaction &tx, TxValidationState &state,
                    const CCoinsViewCache &inputs, int nSpendHeight,
-                   Amount &txfee);
+                   Amount &txfee, const Consensus::Params &params);
 
 } // namespace Consensus
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -9,6 +9,7 @@
 #include <chainparamsconstants.h>
 #include <chainparamsseeds.h>
 #include <consensus/amount.h>
+#include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -151,6 +152,10 @@ public:
 
         // Nov 15, 2024 12:00:00 UTC protocol upgrade
         consensus.augustoActivationTime = 1731672000;
+
+        // Dogecoin: Digishield activation height
+        consensus.digishieldHeight = 145000;
+        consensus.initialCoinbaseMaturity = 30;
 
         /**
          * The message start string is designed to be unlikely to occur in
@@ -299,6 +304,10 @@ public:
         // Nov 15, 2024 12:00:00 UTC protocol upgrade
         consensus.augustoActivationTime = 1731672000;
 
+        // Dogecoin: Digishield activation height
+        consensus.digishieldHeight = 145000;
+        consensus.initialCoinbaseMaturity = 30;
+
         diskMagic[0] = 0xfb;
         diskMagic[1] = 0x87;
         diskMagic[2] = 0xb5;
@@ -426,6 +435,11 @@ public:
 
         // Nov 15, 2024 12:00:00 UTC protocol upgrade
         consensus.augustoActivationTime = 1731672000;
+
+        // Digishield activation height
+        consensus.digishieldHeight = 1450;
+        // keep maturity same as Bitcoin for tests
+        consensus.initialCoinbaseMaturity = REGTEST_COINBASE_MATURITY;
 
         diskMagic[0] = 0x94;
         diskMagic[1] = 0xb1;

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -356,7 +356,10 @@ QString TransactionDesc::toHTML(interfaces::Node &node,
     }
 
     if (wtx.is_coinbase) {
-        quint32 numBlocksToMaturity = COINBASE_MATURITY + 1;
+        quint32 numBlocksToMaturity =
+            CoinbaseMaturity(wallet.getChainParams().GetConsensus(),
+                             wallet.wallet->GetLastBlockHeight()) +
+            1;
         strHTML +=
             "<br>" +
             tr("Generated coins must mature %1 blocks before they can be "

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -41,7 +41,7 @@ void initialize_process_message() {
         MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
 
-    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+    for (int i = 0; i < 2 * REGTEST_COINBASE_MATURITY; i++) {
         MineBlock(GetConfig(), g_setup->m_node, CScript() << OP_TRUE);
     }
     SyncWithValidationInterfaceQueue();

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -25,7 +25,7 @@ void initialize_process_messages() {
     static const auto testing_setup =
         MakeNoLogFileContext<const TestingSetup>();
     g_setup = testing_setup.get();
-    for (int i = 0; i < 2 * COINBASE_MATURITY; i++) {
+    for (int i = 0; i < 2 * REGTEST_COINBASE_MATURITY; i++) {
         MineBlock(GetConfig(), g_setup->m_node, CScript() << OP_TRUE);
     }
     SyncWithValidationInterfaceQueue();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -317,7 +317,7 @@ TestChain100Setup::TestChain100Setup(
     coinbaseKey.Set(vchKey.begin(), vchKey.end(), true);
 
     // Generate a 100-block chain:
-    this->mineBlocks(COINBASE_MATURITY);
+    this->mineBlocks(REGTEST_COINBASE_MATURITY);
 
     {
         LOCK(::cs_main);

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -371,7 +371,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg) {
         }
 
         // Mature the inputs of the txs
-        for (int j = COINBASE_MATURITY; j > 0; --j) {
+        for (int j = REGTEST_COINBASE_MATURITY; j > 0; --j) {
             last_mined = GoodBlock(config, last_mined->GetHash());
             BOOST_REQUIRE(ProcessBlock(last_mined));
         }
@@ -382,7 +382,8 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg) {
         std::vector<std::shared_ptr<const CBlock>> reorg;
         last_mined = GoodBlock(config, split_hash);
         reorg.push_back(last_mined);
-        for (size_t j = COINBASE_MATURITY + txs.size() + 1; j > 0; --j) {
+        for (size_t j = REGTEST_COINBASE_MATURITY + txs.size() + 1; j > 0;
+             --j) {
             last_mined = GoodBlock(config, last_mined->GetHash());
             reorg.push_back(last_mined);
         }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -437,8 +437,9 @@ void CTxMemPool::check(const CCoinsViewCache &active_coins_tip,
         TxValidationState dummy_state;
         Amount txfee{Amount::zero()};
         assert(!tx.IsCoinBase());
-        assert(Consensus::CheckTxInputs(tx, dummy_state, mempoolDuplicate,
-                                        spendheight, txfee));
+        assert(Consensus::CheckTxInputs(
+            tx, dummy_state, mempoolDuplicate, spendheight, txfee,
+            GetConfig().GetChainParams().GetConsensus()));
         for (const auto &input : tx.vin) {
             mempoolDuplicate.SpendCoin(input.prevout);
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -609,9 +609,9 @@ bool MemPoolAccept::PreChecks(ATMPArgs &args, Workspace &ws) {
 
     // The mempool holds txs for the next block, so pass height+1 to
     // CheckTxInputs
-    if (!Consensus::CheckTxInputs(tx, state, m_view,
-                                  m_active_chainstate.m_chain.Height() + 1,
-                                  ws.m_base_fees)) {
+    if (!Consensus::CheckTxInputs(
+            tx, state, m_view, m_active_chainstate.m_chain.Height() + 1,
+            ws.m_base_fees, args.m_config.GetChainParams().GetConsensus())) {
         // state filled in by CheckTxInputs
         return false;
     }
@@ -1958,7 +1958,7 @@ bool Chainstate::ConnectBlock(const CBlock &block, BlockValidationState &state,
             TxValidationState tx_state;
             if (!isCoinBase &&
                 !Consensus::CheckTxInputs(tx, tx_state, view, pindex->nHeight,
-                                          txfee)) {
+                                          txfee, consensusParams)) {
                 // Any transaction validation failure in ConnectBlock is a block
                 // consensus failure.
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3127,10 +3127,12 @@ int CWallet::GetTxBlocksToMaturity(const CWalletTx &wtx) const {
     if (!wtx.IsCoinBase()) {
         return 0;
     }
+    const int32_t coinbaseMaturity =
+        CoinbaseMaturity(GetChainParams().GetConsensus(), GetLastBlockHeight());
     int chain_depth = GetTxDepthInMainChain(wtx);
     // coinbase tx should not be conflicted
     assert(chain_depth >= 0);
-    return std::max(0, (COINBASE_MATURITY + 1) - chain_depth);
+    return std::max(0, (coinbaseMaturity + 1) - chain_depth);
 }
 
 bool CWallet::IsTxImmatureCoinBase(const CWalletTx &wtx) const {

--- a/test/functional/feature_upgrade_coinbase_maturity.py
+++ b/test/functional/feature_upgrade_coinbase_maturity.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2024 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test coinbase maturity upgrades."""
+
+from test_framework.address import (
+    ADDRESS_ECREG_P2SH_OP_TRUE,
+    ADDRESS_ECREG_UNSPENDABLE,
+    SCRIPT_UNSPENDABLE,
+    SCRIPTSIG_OP_TRUE,
+)
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import COutPoint, CTransaction, CTxIn, CTxOut
+from test_framework.p2p import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.txtools import pad_tx
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+
+class UpgradeCoinbaseMaturityTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-txindex"]]
+
+    def reconnect_p2p(self):
+        self.nodes[0].disconnect_p2ps()
+        return self.nodes[0].add_p2p_connection(P2PDataStore())
+
+    def run_test(self):
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PDataStore())
+
+        coinblockhash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        cointxid = node.getblock(coinblockhash)["tx"][0]
+
+        # Only generate 98 blocks, insufficient for maturity
+        self.generatetoaddress(node, 98, ADDRESS_ECREG_UNSPENDABLE)
+        assert_equal(node.getblockcount(), 99)
+
+        coinvalue = 5000000000
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(cointxid, 16), 0), SCRIPTSIG_OP_TRUE)]
+        tx.vout = [CTxOut(coinvalue - 10000, SCRIPT_UNSPENDABLE)]
+        pad_tx(tx)
+
+        # Insufficient maturity
+        assert_raises_rpc_error(
+            -26,
+            "bad-txns-premature-spend-of-coinbase, tried to spend coinbase at depth 99",
+            node.sendrawtransaction,
+            tx.serialize().hex(),
+        )
+
+        # Generate 1 more block, coins are now mature
+        self.generatetoaddress(node, 1, ADDRESS_ECREG_UNSPENDABLE)
+        assert_equal(node.getblockcount(), 100)
+        node.sendrawtransaction(tx.serialize().hex())
+
+        # Make sure tx got mined
+        minedhash = self.generatetoaddress(node, 1, ADDRESS_ECREG_UNSPENDABLE)[0]
+        assert_equal(node.getrawtransaction(tx.hash, 2)["blockhash"], minedhash)
+
+        # Generate blocks until we're 241 blocks before upgrade height
+        UPGRADE_HEIGHT = 1450
+        OLD_MATURITY = 100
+        DIGISHIELD_MATURITY = 240
+        self.generatetoaddress(
+            node,
+            UPGRADE_HEIGHT - DIGISHIELD_MATURITY - OLD_MATURITY - 2,
+            ADDRESS_ECREG_UNSPENDABLE,
+        )
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - DIGISHIELD_MATURITY - 1)
+
+        # Get us two coins with 239 and 240 maturity at upgrade
+        mature240hash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        mature240txid = node.getblock(mature240hash)["tx"][0]
+        mature239hash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        mature239txid = node.getblock(mature239hash)["tx"][0]
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - DIGISHIELD_MATURITY + 1)
+
+        self.generatetoaddress(
+            node, DIGISHIELD_MATURITY - OLD_MATURITY - 3, ADDRESS_ECREG_UNSPENDABLE
+        )
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - OLD_MATURITY - 2)
+
+        # Generate two coins with 99 and 100 maturity one block before upgrade
+        mature100hash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        mature100txid = node.getblock(mature100hash)["tx"][0]
+        mature99hash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        mature99txid = node.getblock(mature99hash)["tx"][0]
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - OLD_MATURITY)
+
+        self.generatetoaddress(node, OLD_MATURITY - 2, ADDRESS_ECREG_UNSPENDABLE)
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - 2)
+
+        # After that many blocks, we had 8 halvings
+        coinvalue >>= 8
+
+        # For the mempool, we are still 1 block before upgrade.
+        # We can spend the 100 mature coin fine, ...
+        spend100tx = CTransaction()
+        spend100tx.vin = [
+            CTxIn(COutPoint(int(mature100txid, 16), 0), SCRIPTSIG_OP_TRUE)
+        ]
+        spend100tx.vout = [CTxOut(coinvalue - 10000, SCRIPT_UNSPENDABLE)]
+        pad_tx(spend100tx)
+        node.sendrawtransaction(spend100tx.serialize().hex())
+
+        # ...but not the 99 mature coin
+        spend99tx = CTransaction()
+        spend99tx.vin = [CTxIn(COutPoint(int(mature99txid, 16), 0), SCRIPTSIG_OP_TRUE)]
+        spend99tx.vout = [CTxOut(coinvalue - 10000, SCRIPT_UNSPENDABLE)]
+        pad_tx(spend99tx)
+        assert_raises_rpc_error(
+            -26,
+            "bad-txns-premature-spend-of-coinbase, tried to spend coinbase at depth 99",
+            node.sendrawtransaction,
+            spend99tx.serialize().hex(),
+        )
+
+        # Can't mine the 99 mature coin spend, ...
+        block = create_block(
+            int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1)
+        )
+        block.nVersion = 4
+        block.vtx += [spend99tx]
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        peer.send_blocks_and_test(
+            [block],
+            node,
+            success=False,
+            reject_reason="bad-txns-premature-spend-of-coinbase, tried to spend coinbase at depth 99",
+            expect_disconnect=True,
+            timeout=5,
+        )
+        peer = self.reconnect_p2p()
+
+        # ... but we can mine the 100 mature coin spend
+        # Also, this activates the upgrade
+        minedhash1 = self.generatetoaddress(node, 1, ADDRESS_ECREG_UNSPENDABLE)[0]
+        assert_equal(
+            node.getrawtransaction(spend100tx.hash, 2)["blockhash"], minedhash1
+        )
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT - 1)
+
+        # For the mempool the upgrade is now activated, so we can't spend a 239 mature coin
+        spend239tx = CTransaction()
+        spend239tx.vin = [
+            CTxIn(COutPoint(int(mature239txid, 16), 0), SCRIPTSIG_OP_TRUE)
+        ]
+        spend239tx.vout = [CTxOut(coinvalue - 10000, SCRIPT_UNSPENDABLE)]
+        pad_tx(spend239tx)
+        assert_raises_rpc_error(
+            -26,
+            "bad-txns-premature-spend-of-coinbase, tried to spend coinbase at depth 239",
+            node.sendrawtransaction,
+            spend239tx.serialize().hex(),
+        )
+
+        # But, we can spend the 240 mature coin
+        spend240tx = CTransaction()
+        spend240tx.vin = [
+            CTxIn(COutPoint(int(mature240txid, 16), 0), SCRIPTSIG_OP_TRUE)
+        ]
+        spend240tx.vout = [CTxOut(coinvalue - 10000, SCRIPT_UNSPENDABLE)]
+        pad_tx(spend240tx)
+        node.sendrawtransaction(spend240tx.serialize().hex())
+
+        # Can't mine the 239 mature coin spend, ...
+        block = create_block(
+            int(node.getbestblockhash(), 16), create_coinbase(node.getblockcount() + 1)
+        )
+        block.nVersion = 4
+        block.vtx += [spend239tx]
+        block.hashMerkleRoot = block.calc_merkle_root()
+        block.solve()
+        peer.send_blocks_and_test(
+            [block],
+            node,
+            success=False,
+            reject_reason="bad-txns-premature-spend-of-coinbase, tried to spend coinbase at depth 239",
+            expect_disconnect=True,
+        )
+        peer = self.reconnect_p2p()
+
+        # ... but we can mine the 240 mature coin spend
+        minedhash2 = self.generatetoaddress(node, 1, ADDRESS_ECREG_UNSPENDABLE)[0]
+        assert_equal(
+            node.getrawtransaction(spend240tx.hash, 2)["blockhash"], minedhash2
+        )
+        assert_equal(node.getblockcount(), UPGRADE_HEIGHT)
+
+
+if __name__ == "__main__":
+    UpgradeCoinbaseMaturityTest().main()


### PR DESCRIPTION
Dogecoin changes the coinbase maturity at block 145000, so we add an upgrade mechanism for this value.

Keep the maturity on regtest at 100 so we don't have to update all the tests, but we upgrade the maturity at 1450 on regtest to test the upgrade mechanism.

Since more variables will change based on height, `vActivatedConsensus` is added to CChainParams, and the function ConsensusAtHeight allows us to get the rules at the given height.