### PR TITLE
Update MAX_MONEY to 10'000'000'000 COIN

### DIFF
--- a/src/avalanche/test/processor_tests.cpp
+++ b/src/avalanche/test/processor_tests.cpp
@@ -1636,7 +1636,7 @@ BOOST_AUTO_TEST_CASE(quorum_detection_parameter_validation) {
             // Min stake is out of range
             {"-1", "0", "0", false},
             {"-0.01", "0", "0", false},
-            {"21000000000000.01", "0", "0", false},
+            {"10000000000000000.01", "0", "0", false},
 
             // Min connected ratio is out of range
             {"0", "-1", "0", false},
@@ -1652,7 +1652,7 @@ BOOST_AUTO_TEST_CASE(quorum_detection_parameter_validation) {
             {"1", "0.1", "0", true},
             {"10", "0.5", "0", true},
             {"10", "1", "0", true},
-            {"21000000000000.00", "0", "0", true},
+            {"10000000000000000.00", "0", "0", true},
             {"0", "0", "1", true},
             {"0", "0", "100", true},
         };

--- a/src/consensus/amount.h
+++ b/src/consensus/amount.h
@@ -156,13 +156,13 @@ struct Currency {
  * No amount larger than this (in satoshi) is valid.
  *
  * Note that this constant is *not* the total money supply, which in eCash
- * currently happens to be less than 21,000,000 COIN for various reasons,
+ * currently happens to be less than 10,000,000,000 COIN for various reasons,
  * but rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  */
-static constexpr Amount MAX_MONEY = 21000000 * COIN;
+static constexpr Amount MAX_MONEY = int64_t(10000000000LL) * COIN;
 inline bool MoneyRange(const Amount nValue) {
     return nValue >= Amount::zero() && nValue <= MAX_MONEY;
 }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1502,7 +1502,7 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney) {
     BOOST_CHECK(ParseMoney("1234567.89", ret));
     BOOST_CHECK_EQUAL(ret, 123456789 * SATOSHI);
 
-    BOOST_CHECK(ParseMoney("21000000000000.00", ret));
+    BOOST_CHECK(ParseMoney("10000000000000000.00", ret));
     BOOST_CHECK_EQUAL(ret, MAX_MONEY);
 
     const auto XEC = Currency::get().baseunit;
@@ -1566,8 +1566,10 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney) {
     // Max possible value with the max number of digits
     BOOST_CHECK(ParseMoney("9999999999999999.99", ret));
     BOOST_CHECK_EQUAL(ret, int64_t(999999999999999999) * SATOSHI);
+    BOOST_CHECK(ParseMoney("19999999999999999.99", ret));
+    BOOST_CHECK_EQUAL(ret, int64_t(1999999999999999999) * SATOSHI);
     // Attempted 63 bit overflow should fail
-    BOOST_CHECK(!ParseMoney("10000000000000000.00", ret));
+    BOOST_CHECK(!ParseMoney("20000000000000000.00", ret));
     BOOST_CHECK(!ParseMoney("92233720368547758.08", ret));
 
     // Parsing negative amounts must fail

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -73,10 +73,17 @@ bool ParseMoney(const std::string &money_string, Amount &nRet) {
     // because it's on no critical path, and it's very unlikely to support a 19
     // decimal (or more) currency anyway.
     assert(currency.decimals <= 18);
+    const size_t maxStrLen = size_t(19) - currency.decimals;
 
     // guard against 63 bit overflow
-    if (strWhole.size() > (size_t(18) - currency.decimals)) {
+    if (strWhole.size() > maxStrLen) {
         return false;
+    }
+    if (strWhole.size() == maxStrLen) {
+        // Allow 18 decimals, but only with a leading 1
+        if (strWhole[0] > '1') {
+            return false;
+        }
     }
     if (nUnits < Amount::zero() || nUnits > currency.baseunit) {
         return false;

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -527,7 +527,7 @@ class PSBTTest(BitcoinTestFramework):
             "PSBT with invalid values should have error message and Creator as next"
         )
         analysis = self.nodes[0].analyzepsbt(
-            "cHNidP8BAHECAAAAAfA00BFgAm6tp86RowwH6BMImQNL5zXUcTT97XoLGz0BAAAAAAD/////AgD5ApUAAAAAFgAUKNw0x8HRctAgmvoevm4u1SbN7XL87QKVAAAAABYAFPck4gF7iL4NL4wtfRAKgQbghiTUAAAAAAABAB8AgIFq49AHABYAFJUDtxf2PHo641HEOBOAIvFMNTr2AAAA"
+            "cHNidP8BAHECAAAAAfA00BFgAm6tp86RowwH6BMImQNL5zXUcTT97XoLGz0BAAAAAAD/////AgD5ApUAAAAAFgAUKNw0x8HRctAgmvoevm4u1SbN7XL87QKVAAAAABYAFPck4gF7iL4NL4wtfRAKgQbghiTUAAAAAAABAB///8dOZ23BGxYAFJUDtxf2PHo641HEOBOAIvFMNTr2AAAA"
         )
         assert_equal(analysis["next"], "creator")
         assert_equal(analysis["error"], "PSBT is not valid. Input 0 has invalid value")
@@ -539,7 +539,7 @@ class PSBTTest(BitcoinTestFramework):
         assert_equal(analysis["next"], "finalizer")
 
         analysis = self.nodes[0].analyzepsbt(
-            "cHNidP8BAHECAAAAAfA00BFgAm6tp86RowwH6BMImQNL5zXUcTT97XoLGz0BAAAAAAD/////AgCAgWrj0AcAFgAUKNw0x8HRctAgmvoevm4u1SbN7XL87QKVAAAAABYAFPck4gF7iL4NL4wtfRAKgQbghiTUAAAAAAABAB8A8gUqAQAAABYAFJUDtxf2PHo641HEOBOAIvFMNTr2AAAA"
+            "cHNidP8BAHECAAAAAfA00BFgAm6tp86RowwH6BMImQNL5zXUcTT97XoLGz0BAAAAAAD/////Av//x05nbcEbFgAUKNw0x8HRctAgmvoevm4u1SbN7XL87QKVAAAAABYAFPck4gF7iL4NL4wtfRAKgQbghiTUAAAAAAABAB8A8gUqAQAAABYAFJUDtxf2PHo641HEOBOAIvFMNTr2AAAA"
         )
         assert_equal(analysis["next"], "creator")
         assert_equal(analysis["error"], "PSBT is not valid. Output amount invalid")

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -41,7 +41,7 @@ MAX_BLOOM_HASH_FUNCS = 50
 COIN = 100000000
 # 1 XEC in satoshis
 XEC = 100
-MAX_MONEY = 21000000 * COIN
+MAX_MONEY = 10_000_000_000 * COIN
 
 # Maximum length of incoming protocol messages
 MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024


### PR DESCRIPTION
Dogecoin has a MAX_MONEY value of 10bln DOGE.

It also requires us to update ParseMoney as it now needs to handle 19 char long strings.