### PR TITLE
Fix CoinbaseMaturity upgrade

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -181,9 +181,13 @@ bool CheckTxInputs(const CTransaction &tx, TxValidationState &state,
         const Coin &coin = inputs.AccessCoin(prevout);
         assert(!coin.IsSpent());
 
+        // Dogecoin: Coinbase maturity depends on the coin's height
+        const int32_t minCoinbaseMaturity =
+            CoinbaseMaturity(params, coin.GetHeight());
+
         // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase() && nSpendHeight - (int)coin.GetHeight() <
-                                     CoinbaseMaturity(params, nSpendHeight)) {
+        if (coin.IsCoinBase() &&
+            nSpendHeight - (int)coin.GetHeight() < minCoinbaseMaturity) {
             return state.Invalid(
                 TxValidationResult::TX_PREMATURE_SPEND,
                 "bad-txns-premature-spend-of-coinbase",

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -359,7 +359,7 @@ QString TransactionDesc::toHTML(interfaces::Node &node,
     if (wtx.is_coinbase) {
         quint32 numBlocksToMaturity =
             CoinbaseMaturity(wallet.getChainParams().GetConsensus(),
-                             wallet.wallet()->GetLastBlockHeight()) +
+                             status.block_height) +
             1;
         strHTML +=
             "<br>" +

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3127,8 +3127,8 @@ int CWallet::GetTxBlocksToMaturity(const CWalletTx &wtx) const {
     if (!wtx.IsCoinBase()) {
         return 0;
     }
-    const int32_t coinbaseMaturity =
-        CoinbaseMaturity(GetChainParams().GetConsensus(), GetLastBlockHeight());
+    const int32_t coinbaseMaturity = CoinbaseMaturity(
+        GetChainParams().GetConsensus(), wtx.m_confirm.block_height);
     int chain_depth = GetTxDepthInMainChain(wtx);
     // coinbase tx should not be conflicted
     assert(chain_depth >= 0);


### PR DESCRIPTION
It was erroneously assumed that the upgrade height would be based on the height where the coin is *spent*, not where it's *mined*, which is how it actually works in Dogecoin.

This basically simply offsets the upgrade.