### PR TITLE
Fix feerates near MAX_MONEY

### DIFF
--- a/src/feerate.cpp
+++ b/src/feerate.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <feerate.h>
+#include <policy/fees.h>
 
 #include <tinyformat.h>
 
@@ -12,8 +13,12 @@ CFeeRate::CFeeRate(const Amount nFeePaid, size_t nBytes_) {
     assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
     int64_t nSize = int64_t(nBytes_);
 
-    if (nSize > 0) {
-        nSatoshisPerK = 1000 * nFeePaid / nSize;
+    if (nFeePaid > MAX_MONEY / 1000) {
+        // This computation will not fit in Amount. Since it is not realistic,
+        // just set the max fee rate.
+        nSatoshisPerK = MAX_FEERATE;
+    } else if (nSize > 0) {
+        nSatoshisPerK = (1000 * nFeePaid) / nSize;
     } else {
         nSatoshisPerK = Amount::zero();
     }

--- a/src/test/feerate_tests.cpp
+++ b/src/test/feerate_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <consensus/amount.h>
 
+#include <policy/fees.h>
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
@@ -84,8 +85,21 @@ BOOST_AUTO_TEST_CASE(GetFeeTest) {
     // some more integer checks
     BOOST_CHECK(CFeeRate(26 * SATOSHI, 789) == CFeeRate(32 * SATOSHI));
     BOOST_CHECK(CFeeRate(27 * SATOSHI, 789) == CFeeRate(34 * SATOSHI));
+    // Near computation boundary
+    BOOST_CHECK(CFeeRate(MAX_MONEY / 1000 - Amount::satoshi(),
+                         std::numeric_limits<size_t>::max() >> 1) ==
+                CFeeRate(Amount::zero()));
+    BOOST_CHECK(CFeeRate(MAX_MONEY / 1000, std::numeric_limits<size_t>::max() >>
+                                               1) == CFeeRate(Amount::zero()));
+    BOOST_CHECK(CFeeRate(MAX_MONEY / 1000 + Amount::satoshi(),
+                         std::numeric_limits<size_t>::max() >> 1) ==
+                CFeeRate(MAX_FEERATE));
     // Maximum size in bytes, should not crash
-    CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1).GetFeePerK();
+    BOOST_CHECK(CFeeRate(MAX_MONEY - Amount::satoshi(),
+                         std::numeric_limits<size_t>::max() >> 1) ==
+                CFeeRate(MAX_FEERATE));
+    BOOST_CHECK(CFeeRate(MAX_MONEY, std::numeric_limits<size_t>::max() >> 1) ==
+                CFeeRate(MAX_FEERATE));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Until Amount can support larger computations (MAX_MONEY * 1000) just set the feerate to something manageable. This is not a realistic nFeePaid anyway.