### PR TITLE
Fix extended tests (feature_dbcrash, feature_block)

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -518,10 +518,11 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(44)
         b47 = self.next_block(47)
         target = uint256_from_compact(b47.nBits)
-        while b47.sha256 <= target:
+        while b47.powHash <= target:
             # Rehash nonces until an invalid too-high-hash block is found.
             b47.nNonce += 1
-            b47.rehash()
+            b47.rehashPow()
+        b47.rehash()
         self.send_blocks(
             [b47], False, force_send=True, reject_reason="high-hash", reconnect=True
         )

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -230,7 +230,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         # Start by creating a lot of utxos on node3
         initial_height = self.nodes[3].getblockcount()
         utxo_list = create_confirmed_utxos(
-            self, self.nodes[3], 5000, sync_fun=self.no_op
+            self, self.nodes[3], 5000, sync_fun=self.no_op, age=240,
         )
         self.log.info(f"Prepped {len(utxo_list)} utxo entries")
 


### PR DESCRIPTION
- feature_dbcrash broke because we bump the COINBASE_MATURITY after block 1450.
- feature_block broke because the block's hash is no longer the powHash.