### PR TITLE
Move merkle funcs from merkle_tests to test/util/merkle

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(testutil OBJECT
 	util/blockindex.cpp
 	util/coins.cpp
 	util/logging.cpp
+	util/merkle.cpp
 	util/mining.cpp
 	util/net.cpp
 	util/random.cpp

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -6,6 +6,7 @@
 
 #include <util/strencodings.h>
 
+#include <test/util/merkle.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 
@@ -28,127 +29,6 @@ ComputeMerkleRootFromBranch(const uint256 &leaf,
         nIndex >>= 1;
     }
     return hash;
-}
-
-/**
- * This implements a constant-space merkle root/path calculator, limited to 2^32
- * leaves.
- */
-static void MerkleComputation(const std::vector<uint256> &leaves,
-                              uint256 *proot, bool *pmutated,
-                              uint32_t branchpos,
-                              std::vector<uint256> *pbranch) {
-    if (pbranch) {
-        pbranch->clear();
-    }
-    if (leaves.size() == 0) {
-        if (pmutated) {
-            *pmutated = false;
-        }
-        if (proot) {
-            *proot = uint256();
-        }
-        return;
-    }
-    bool mutated = false;
-    // count is the number of leaves processed so far.
-    uint32_t count = 0;
-    // inner is an array of eagerly computed subtree hashes, indexed by tree
-    // level (0 being the leaves).
-    // For example, when count is 25 (11001 in binary), inner[4] is the hash of
-    // the first 16 leaves, inner[3] of the next 8 leaves, and inner[0] equal to
-    // the last leaf. The other inner entries are undefined.
-    uint256 inner[32];
-    // Which position in inner is a hash that depends on the matching leaf.
-    int matchlevel = -1;
-    // First process all leaves into 'inner' values.
-    while (count < leaves.size()) {
-        uint256 h = leaves[count];
-        bool matchh = count == branchpos;
-        count++;
-        int level;
-        // For each of the lower bits in count that are 0, do 1 step. Each
-        // corresponds to an inner value that existed before processing the
-        // current leaf, and each needs a hash to combine it.
-        for (level = 0; !(count & (((uint32_t)1) << level)); level++) {
-            if (pbranch) {
-                if (matchh) {
-                    pbranch->push_back(inner[level]);
-                } else if (matchlevel == level) {
-                    pbranch->push_back(h);
-                    matchh = true;
-                }
-            }
-            mutated |= (inner[level] == h);
-            CHash256().Write(inner[level]).Write(h).Finalize(h);
-        }
-        // Store the resulting hash at inner position level.
-        inner[level] = h;
-        if (matchh) {
-            matchlevel = level;
-        }
-    }
-    // Do a final 'sweep' over the rightmost branch of the tree to process
-    // odd levels, and reduce everything to a single top value.
-    // Level is the level (counted from the bottom) up to which we've sweeped.
-    int level = 0;
-    // As long as bit number level in count is zero, skip it. It means there
-    // is nothing left at this level.
-    while (!(count & (((uint32_t)1) << level))) {
-        level++;
-    }
-    uint256 h = inner[level];
-    bool matchh = matchlevel == level;
-    while (count != (((uint32_t)1) << level)) {
-        // If we reach this point, h is an inner value that is not the top.
-        // We combine it with itself (Bitcoin's special rule for odd levels in
-        // the tree) to produce a higher level one.
-        if (pbranch && matchh) {
-            pbranch->push_back(h);
-        }
-        CHash256().Write(h).Write(h).Finalize(h);
-        // Increment count to the value it would have if two entries at this
-        // level had existed.
-        count += (((uint32_t)1) << level);
-        level++;
-        // And propagate the result upwards accordingly.
-        while (!(count & (((uint32_t)1) << level))) {
-            if (pbranch) {
-                if (matchh) {
-                    pbranch->push_back(inner[level]);
-                } else if (matchlevel == level) {
-                    pbranch->push_back(h);
-                    matchh = true;
-                }
-            }
-            CHash256().Write(inner[level]).Write(h).Finalize(h);
-            level++;
-        }
-    }
-    // Return result.
-    if (pmutated) {
-        *pmutated = mutated;
-    }
-    if (proot) {
-        *proot = h;
-    }
-}
-
-static std::vector<uint256>
-ComputeMerkleBranch(const std::vector<uint256> &leaves, uint32_t position) {
-    std::vector<uint256> ret;
-    MerkleComputation(leaves, nullptr, nullptr, position, &ret);
-    return ret;
-}
-
-static std::vector<uint256> BlockMerkleBranch(const CBlock &block,
-                                              uint32_t position) {
-    std::vector<uint256> leaves;
-    leaves.resize(block.vtx.size());
-    for (size_t s = 0; s < block.vtx.size(); s++) {
-        leaves[s] = block.vtx[s]->GetHash();
-    }
-    return ComputeMerkleBranch(leaves, position);
 }
 
 // Older version of the merkle root computation code, for comparison.

--- a/src/test/util/merkle.cpp
+++ b/src/test/util/merkle.cpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <hash.h>
+#include <primitives/block.h>
+#include <uint256.h>
+
+#include <vector>
+
+/**
+ * This implements a constant-space merkle root/path calculator, limited to 2^32
+ * leaves.
+ */
+void MerkleComputation(const std::vector<uint256> &leaves, uint256 *proot,
+                       bool *pmutated, uint32_t branchpos,
+                       std::vector<uint256> *pbranch) {
+    if (pbranch) {
+        pbranch->clear();
+    }
+    if (leaves.size() == 0) {
+        if (pmutated) {
+            *pmutated = false;
+        }
+        if (proot) {
+            *proot = uint256();
+        }
+        return;
+    }
+    bool mutated = false;
+    // count is the number of leaves processed so far.
+    uint32_t count = 0;
+    // inner is an array of eagerly computed subtree hashes, indexed by tree
+    // level (0 being the leaves).
+    // For example, when count is 25 (11001 in binary), inner[4] is the hash of
+    // the first 16 leaves, inner[3] of the next 8 leaves, and inner[0] equal to
+    // the last leaf. The other inner entries are undefined.
+    uint256 inner[32];
+    // Which position in inner is a hash that depends on the matching leaf.
+    int matchlevel = -1;
+    // First process all leaves into 'inner' values.
+    while (count < leaves.size()) {
+        uint256 h = leaves[count];
+        bool matchh = count == branchpos;
+        count++;
+        int level;
+        // For each of the lower bits in count that are 0, do 1 step. Each
+        // corresponds to an inner value that existed before processing the
+        // current leaf, and each needs a hash to combine it.
+        for (level = 0; !(count & (((uint32_t)1) << level)); level++) {
+            if (pbranch) {
+                if (matchh) {
+                    pbranch->push_back(inner[level]);
+                } else if (matchlevel == level) {
+                    pbranch->push_back(h);
+                    matchh = true;
+                }
+            }
+            mutated |= (inner[level] == h);
+            CHash256().Write(inner[level]).Write(h).Finalize(h);
+        }
+        // Store the resulting hash at inner position level.
+        inner[level] = h;
+        if (matchh) {
+            matchlevel = level;
+        }
+    }
+    // Do a final 'sweep' over the rightmost branch of the tree to process
+    // odd levels, and reduce everything to a single top value.
+    // Level is the level (counted from the bottom) up to which we've sweeped.
+    int level = 0;
+    // As long as bit number level in count is zero, skip it. It means there
+    // is nothing left at this level.
+    while (!(count & (((uint32_t)1) << level))) {
+        level++;
+    }
+    uint256 h = inner[level];
+    bool matchh = matchlevel == level;
+    while (count != (((uint32_t)1) << level)) {
+        // If we reach this point, h is an inner value that is not the top.
+        // We combine it with itself (Bitcoin's special rule for odd levels in
+        // the tree) to produce a higher level one.
+        if (pbranch && matchh) {
+            pbranch->push_back(h);
+        }
+        CHash256().Write(h).Write(h).Finalize(h);
+        // Increment count to the value it would have if two entries at this
+        // level had existed.
+        count += (((uint32_t)1) << level);
+        level++;
+        // And propagate the result upwards accordingly.
+        while (!(count & (((uint32_t)1) << level))) {
+            if (pbranch) {
+                if (matchh) {
+                    pbranch->push_back(inner[level]);
+                } else if (matchlevel == level) {
+                    pbranch->push_back(h);
+                    matchh = true;
+                }
+            }
+            CHash256().Write(inner[level]).Write(h).Finalize(h);
+            level++;
+        }
+    }
+    // Return result.
+    if (pmutated) {
+        *pmutated = mutated;
+    }
+    if (proot) {
+        *proot = h;
+    }
+}
+
+std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256> &leaves,
+                                         uint32_t position) {
+    std::vector<uint256> ret;
+    MerkleComputation(leaves, nullptr, nullptr, position, &ret);
+    return ret;
+}
+
+std::vector<uint256> BlockMerkleBranch(const CBlock &block, uint32_t position) {
+    std::vector<uint256> leaves;
+    leaves.resize(block.vtx.size());
+    for (size_t s = 0; s < block.vtx.size(); s++) {
+        leaves[s] = block.vtx[s]->GetHash();
+    }
+    return ComputeMerkleBranch(leaves, position);
+}

--- a/src/test/util/merkle.h
+++ b/src/test/util/merkle.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_MERKLE_H
+#define BITCOIN_TEST_UTIL_MERKLE_H
+
+/**
+ * This implements a constant-space merkle root/path calculator, limited to 2^32
+ * leaves.
+ */
+void MerkleComputation(const std::vector<uint256> &leaves, uint256 *proot,
+                       bool *pmutated, uint32_t branchpos,
+                       std::vector<uint256> *pbranch);
+
+std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256> &leaves,
+                                         uint32_t position);
+
+std::vector<uint256> BlockMerkleBranch(const CBlock &block, uint32_t position);
+
+#endif // BITCOIN_TEST_UTIL_MERKLE_H


### PR DESCRIPTION
These are required to test AuxPow, but not outside of testing, so we just move them to the test utils.