### PR TITLE
Set default -datacarriersize to 83

### DIFF
--- a/chronik/test/chronikbridge_tests.cpp
+++ b/chronik/test/chronikbridge_tests.cpp
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(test_bridge_broadcast_tx, TestChain100Setup) {
 
     const CTransactionRef coinTx = coinsBlock.vtx[0];
 
-    CScript scriptPad = CScript() << OP_RETURN << std::vector<uint8_t>(100);
+    CScript scriptPad = CScript() << OP_RETURN << std::vector<uint8_t>(80);
     CMutableTransaction tx;
     tx.vin = {CTxIn(coinTx->GetId(), 0)};
     tx.vout = {

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -30,10 +30,10 @@ public:
 };
 
 /**
- * Default setting for nMaxDatacarrierBytes. 220 bytes of data, +1 for
+ * Default setting for nMaxDatacarrierBytes. 80 bytes of data, +1 for
  * OP_RETURN, +2 for the pushdata opcodes.
  */
-static const unsigned int MAX_OP_RETURN_RELAY = 223;
+static const unsigned int MAX_OP_RETURN_RELAY = 83;
 
 enum class TxoutType {
     NONSTANDARD,

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -668,34 +668,22 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
 
     // MAX_OP_RETURN_RELAY-byte TxoutType::NULL_DATA (standard)
     t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
-                              "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3"
-                              "952b99a2981873e74509281730d78a21786d34a38bd1ebab"
-                              "822fad42278f7f4420db6ab1fd2b6826148d4f73bb41ec2d"
-                              "40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d"
-                              "53609d350038df0a1b2a9ac8332016e0b904f66880dd0108"
-                              "81c4e8074cce8e4ad6c77cb3460e01bf0e7e811b5f945f83"
-                              "732ba6677520a893d75d9a966cb8f85dc301656b1635c631"
-                              "f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed1"
-                              "3afb2ab8");
+        CScript()
+        << OP_RETURN
+        << ParseHex("646578784062697477617463682e636f2092c558ed52c56d8dd14ca762"
+                    "26bc936a84820d898443873eb03d8854b21fa3952b99a2981873e74509"
+                    "281730d78a21786d34a38bd1ebab822fad42278f7f44");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY, g_bare_multi,
                              g_dust, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TxoutType::NULL_DATA (non-standard)
     t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
-                              "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3"
-                              "952b99a2981873e74509281730d78a21786d34a38bd1ebab"
-                              "822fad42278f7f4420db6ab1fd2b6826148d4f73bb41ec2d"
-                              "40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d"
-                              "53609d350038df0a1b2a9ac8332016e0b904f66880dd0108"
-                              "81c4e8074cce8e4ad6c77cb3460e01bf0e7e811b5f945f83"
-                              "732ba6677520a893d75d9a966cb8f85dc301656b1635c631"
-                              "f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed1"
-                              "3afb2ab800");
+        CScript()
+        << OP_RETURN
+        << ParseHex("646578784062697477617463682e636f2092c558ed52c56d8dd14ca762"
+                    "26bc936a84820d898443873eb03d8854b21fa3952b99a2981873e74509"
+                    "281730d78a21786d34a38bd1ebab822fad42278f7f4400");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
     reason.clear();
     BOOST_CHECK(!IsStandardTx(CTransaction{t}, MAX_OP_RETURN_RELAY,

--- a/test/functional/chronik_avalanche.py
+++ b/test/functional/chronik_avalanche.py
@@ -84,7 +84,7 @@ class ChronikAvalancheTest(BitcoinTestFramework):
         ]
         tx.vout = [
             CTxOut(
-                nValue=coinvalue - 10000, scriptPubKey=CScript([OP_RETURN, bytes(100)])
+                nValue=coinvalue - 10000, scriptPubKey=CScript([OP_RETURN, bytes(80)])
             )
         ]
 

--- a/test/functional/chronik_lokad_id_group.py
+++ b/test/functional/chronik_lokad_id_group.py
@@ -108,7 +108,7 @@ class ChronikLokadIdGroup(BitcoinTestFramework):
         node.setmocktime(mocktime + 1)
         tx1 = CTransaction()
         tx1.vin = [CTxIn(COutPoint(tx0.sha256, 1), spend_p2lokad(b"lok1"))]
-        tx1.vout = [CTxOut(0, CScript([OP_RETURN, b"lok0", b"x" * 100]))]
+        tx1.vout = [CTxOut(0, CScript([OP_RETURN, b"lok0", b"x" * 70]))]
         tx1.rehash()
         chronik.broadcast_tx(tx1.serialize()).ok()
         assert_equal(lokad_id_unconf(b"lok0"), [tx0.hash, tx1.hash])
@@ -126,7 +126,7 @@ class ChronikLokadIdGroup(BitcoinTestFramework):
         tx2.vin = [CTxIn(COutPoint(tx0.sha256, 2), spend_p2lokad(b"lok2"))]
         tx2.vout = [
             CTxOut(
-                0, CScript([OP_RETURN, OP_RESERVED, b"lok2__", b"lok0" + b"x" * 100])
+                0, CScript([OP_RETURN, OP_RESERVED, b"lok2__", b"lok0" + b"x" * 60])
             )
         ]
         tx2.rehash()
@@ -152,7 +152,7 @@ class ChronikLokadIdGroup(BitcoinTestFramework):
         tx3 = CTransaction()
         tx3.vin = [CTxIn(COutPoint(tx0.sha256, 3), spend_p2lokad(b"lok3"))]
         tx3.vout = [
-            CTxOut(0, CScript([OP_RETURN, OP_RESERVED, b"lok2", b"lok0" + b"x" * 100]))
+            CTxOut(0, CScript([OP_RETURN, OP_RESERVED, b"lok2", b"lok0" + b"x" * 60]))
         ]
         tx3.rehash()
         chronik.broadcast_tx(tx3.serialize()).ok()
@@ -182,7 +182,7 @@ class ChronikLokadIdGroup(BitcoinTestFramework):
         tx3_conflict = CTransaction()
         tx3_conflict.vin = [CTxIn(COutPoint(tx0.sha256, 3), spend_p2lokad(b"lok3"))]
         tx3_conflict.vout = [
-            CTxOut(0, CScript([OP_RETURN, OP_RESERVED, b"lok4" + b"x" * 100]))
+            CTxOut(0, CScript([OP_RETURN, OP_RESERVED, b"lok4" + b"x" * 60]))
         ]
         tx3_conflict.rehash()
 

--- a/test/functional/chronik_script_unconfirmed_txs.py
+++ b/test/functional/chronik_script_unconfirmed_txs.py
@@ -123,7 +123,7 @@ class ChronikScriptUnconfirmedTxsTest(BitcoinTestFramework):
         for mocktime_offset in mocktime_offsets:
             cointxid = cointxids.pop(0)
             time_first_seen = mocktime + mocktime_offset
-            pad_script = CScript([OP_RETURN, bytes(100)])
+            pad_script = CScript([OP_RETURN, bytes(80)])
 
             tx = CTransaction()
             tx.nVersion = 1

--- a/test/functional/chronik_token_alp.py
+++ b/test/functional/chronik_token_alp.py
@@ -34,7 +34,7 @@ class ChronikTokenAlp(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()

--- a/test/functional/chronik_token_burn.py
+++ b/test/functional/chronik_token_burn.py
@@ -22,7 +22,7 @@ class ChronikTokenBurn(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()

--- a/test/functional/chronik_token_id_group.py
+++ b/test/functional/chronik_token_id_group.py
@@ -25,7 +25,7 @@ class ChronikTokenBurn(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()

--- a/test/functional/chronik_token_slp_fungible.py
+++ b/test/functional/chronik_token_slp_fungible.py
@@ -21,7 +21,7 @@ class ChronikTokenSlpFungible(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()

--- a/test/functional/chronik_token_slp_mint_vault.py
+++ b/test/functional/chronik_token_slp_mint_vault.py
@@ -29,7 +29,7 @@ class ChronikTokenSlpMintVault(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()

--- a/test/functional/chronik_token_slp_nft1.py
+++ b/test/functional/chronik_token_slp_nft1.py
@@ -21,7 +21,7 @@ class ChronikTokenSlpNft1(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-chronik"]]
+        self.extra_args = [["-chronik", "-datacarriersize=223"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_chronik()


### PR DESCRIPTION
Dogecoin still has the old 80 bytes limit on OP_RETURN txs, so we lower the default value and adjust tests accordingly.