### PR TITLE
Add CountScriptSigOps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -704,6 +704,7 @@ add_library(server
 	rpc/txoutproof.cpp
 	script/scriptcache.cpp
 	script/sigcache.cpp
+	script/sigops.cpp
 	shutdown.cpp
 	timedata.cpp
 	torcontrol.cpp

--- a/src/script/sigops.cpp
+++ b/src/script/sigops.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/script.h>
+#include <script/sigops.h>
+
+uint32_t CountScriptSigOps(const CScript &script, SigOpCountMode mode) {
+    uint32_t nSigOps = 0;
+    CScript::const_iterator pc = script.begin();
+    opcodetype prevOpcode = OP_INVALIDOPCODE;
+
+    while (pc < script.end()) {
+        opcodetype opcode;
+        if (!script.GetOp(pc, opcode)) {
+            break;
+        }
+
+        switch (opcode) {
+            case OP_CHECKSIG:
+            case OP_CHECKSIGVERIFY:
+                nSigOps++;
+                break;
+
+            case OP_CHECKDATASIG:
+            case OP_CHECKDATASIGVERIFY:
+                // Dogecoin: These opcodes don't exist on Dogecoin and therefore
+                // don't count as sigops.
+                // It's important to not count them as unexecuted sigops still
+                // would count and could lead to a fork.
+                break;
+
+            case OP_CHECKMULTISIG:
+            case OP_CHECKMULTISIGVERIFY:
+                if (mode == SigOpCountMode::ACCURATE && prevOpcode >= OP_1 &&
+                    prevOpcode <= OP_16) {
+                    nSigOps += CScript::DecodeOP_N(prevOpcode);
+                } else {
+                    nSigOps += MAX_PUBKEYS_PER_MULTISIG;
+                }
+                break;
+
+            default:
+                break;
+        }
+
+        prevOpcode = opcode;
+    }
+
+    return nSigOps;
+}

--- a/src/script/sigops.h
+++ b/src/script/sigops.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+class CScript;
+
+enum class SigOpCountMode {
+    ACCURATE,
+    ESTIMATED,
+};
+
+uint32_t CountScriptSigOps(const CScript &script, SigOpCountMode mode);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -228,6 +228,7 @@ add_boost_unit_tests_to_suite(bitcoin test_bitcoin
 		sighash_tests.cpp
 		sighashtype_tests.cpp
 		sigcheckcount_tests.cpp
+		sigops_tests.cpp
 		skiplist_tests.cpp
 		sock_tests.cpp
 		streams_tests.cpp

--- a/src/test/sigops_tests.cpp
+++ b/src/test/sigops_tests.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <script/script.h>
+#include <script/sigops.h>
+#include <script/standard.h>
+
+BOOST_AUTO_TEST_SUITE(sigops_tests)
+
+BOOST_AUTO_TEST_CASE(CountScriptSigOps_test) {
+    CScript s1;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ESTIMATED), 0);
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 0);
+
+    std::vector<uint8_t> dummy(20);
+
+    s1 << OP_1 << dummy << dummy << OP_2 << OP_CHECKMULTISIG;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 2);
+    s1 << OP_IF << OP_CHECKSIG << OP_ENDIF;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 3);
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ESTIMATED), 21);
+    s1 << OP_CHECKSIGVERIFY;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 4);
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ESTIMATED), 22);
+
+    // OP_CHECKDATASIG and OP_CHECKDATASIGVERIFY don't count as SigOps
+    s1 << OP_CHECKDATASIG;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 4);
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ESTIMATED), 22);
+    s1 << OP_CHECKDATASIGVERIFY;
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ACCURATE), 4);
+    BOOST_CHECK_EQUAL(CountScriptSigOps(s1, SigOpCountMode::ESTIMATED), 22);
+
+    {
+        // bare OP_CHECKMULTISIG has an "accurate" count of 20
+        CScript s;
+        s << OP_CHECKMULTISIG;
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ACCURATE), 20);
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ESTIMATED), 20);
+    }
+
+    {
+        // 1-of-0 multisig has an "accurate" count of 20
+        CScript s = GetScriptForMultisig(1, {});
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ACCURATE), 20);
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ESTIMATED), 20);
+    }
+
+    for (size_t i = 1; i <= 16; ++i) {
+        std::vector<CPubKey> keys(i);
+        CScript s = GetScriptForMultisig(1, keys);
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ACCURATE), i);
+        BOOST_CHECK_EQUAL(CountScriptSigOps(s, SigOpCountMode::ESTIMATED), 20);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds back in a simplified version of `CScript::GetSigOpCount` (originally removed in D6101), but keeps it separate in the function `CountScriptSigOps`.

The function and Dogecoin's GetSigOpCount are identical in behavior, and OP_CHECKDATASIG(VERIFY) don't count as SigOps to avoid a fork.