### PR TITLE
Add CountScriptSigOpsP2SH to count sigops in P2SH

### DIFF
--- a/src/script/sigops.cpp
+++ b/src/script/sigops.cpp
@@ -49,3 +49,22 @@ uint32_t CountScriptSigOps(const CScript &script, SigOpCountMode mode) {
 
     return nSigOps;
 }
+
+uint32_t CountScriptSigOpsP2SH(const CScript &scriptSig) {
+    // Get the last item that the scriptSig pushes onto the stack:
+    CScript::const_iterator pc = scriptSig.begin();
+    std::vector<uint8_t> vData;
+    while (pc < scriptSig.end()) {
+        opcodetype opcode;
+        if (!scriptSig.GetOp(pc, opcode, vData)) {
+            return 0;
+        }
+        if (opcode > OP_16) {
+            return 0;
+        }
+    }
+
+    // ... and return its opcount, using "ACCURATE" counting:
+    CScript subscript(vData.begin(), vData.end());
+    return CountScriptSigOps(subscript, SigOpCountMode::ACCURATE);
+}

--- a/src/script/sigops.h
+++ b/src/script/sigops.h
@@ -10,3 +10,5 @@ enum class SigOpCountMode {
 };
 
 uint32_t CountScriptSigOps(const CScript &script, SigOpCountMode mode);
+
+uint32_t CountScriptSigOpsP2SH(const CScript &scriptSig);

--- a/src/test/sigops_tests.cpp
+++ b/src/test/sigops_tests.cpp
@@ -57,4 +57,63 @@ BOOST_AUTO_TEST_CASE(CountScriptSigOps_test) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(CountScriptSigOpsP2SH_test) {
+    BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript()), 0);
+    BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript() << OP_CHECKSIG), 0);
+
+    std::vector<uint8_t> dummy(20);
+
+    {
+        CScript script;
+        script << OP_CHECKSIG;
+        std::vector<uint8_t> scriptBytes(script.begin(), script.end());
+        BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript() << scriptBytes), 1);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << dummy << scriptBytes), 1);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << scriptBytes << dummy), 0);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << OP_CHECKSIG << scriptBytes), 0);
+    }
+
+    {
+        CScript script;
+        script << OP_CHECKSIG << OP_CHECKSIGVERIFY;
+        std::vector<uint8_t> scriptBytes(script.begin(), script.end());
+        BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript() << scriptBytes), 2);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << dummy << scriptBytes), 2);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << scriptBytes << dummy), 0);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << OP_CHECKSIG << scriptBytes), 0);
+    }
+
+    {
+        CScript script;
+        script << OP_1 << dummy << dummy << OP_4 << OP_CHECKMULTISIG;
+        std::vector<uint8_t> scriptBytes(script.begin(), script.end());
+        BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript() << scriptBytes), 4);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << dummy << scriptBytes), 4);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << scriptBytes << dummy), 0);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << OP_CHECKSIG << scriptBytes), 0);
+    }
+
+    {
+        CScript script;
+        script << OP_CHECKMULTISIG;
+        std::vector<uint8_t> scriptBytes(script.begin(), script.end());
+        BOOST_CHECK_EQUAL(CountScriptSigOpsP2SH(CScript() << scriptBytes), 20);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << dummy << scriptBytes), 20);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << scriptBytes << dummy), 0);
+        BOOST_CHECK_EQUAL(
+            CountScriptSigOpsP2SH(CScript() << OP_CHECKSIG << scriptBytes), 0);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Takes a scriptSig and counts the sigops found on the redeemScript, i.e. the last pushop interpreted as a Script.

This is based on the `CScript::GetSigOpCount` deleted in https://reviews.bitcoinabc.org/D6105; but here it's assumed the script is P2SH, which simplifies the implementation.