### PR TITLE
Add Dogecoin MANDATORY_SCRIPT_VERIFY_FLAGS and STANDARD_SCRIPT_VERIFY_FLAGS

### DIFF
--- a/src/consensus/activation.cpp
+++ b/src/consensus/activation.cpp
@@ -132,3 +132,10 @@ bool IsAugustoEnabled(const Consensus::Params &params,
 bool IsDigishieldEnabled(const Consensus::Params &params, int32_t nHeight) {
     return nHeight >= params.digishieldHeight;
 }
+
+// Command-line argument "-legacyscriptrules" will make the node enforce the old
+// script rules (see SCRIPT_VERIFY_LEGACY_RULES).
+bool IsLegacyScriptRulesEnabled(const Consensus::Params &params) {
+    return gArgs.GetBoolArg("-legacyscriptrules",
+                            params.enforceLegacyScriptRules);
+}

--- a/src/consensus/activation.h
+++ b/src/consensus/activation.h
@@ -60,4 +60,7 @@ bool IsAugustoEnabled(const Consensus::Params &params,
 /** Check if Dogecoin Digishield protocol upgrade has activated. */
 bool IsDigishieldEnabled(const Consensus::Params &params, int32_t nHeight);
 
+/** Check if the legacy script rules are active (not based on height) */
+bool IsLegacyScriptRulesEnabled(const Consensus::Params &params);
+
 #endif // BITCOIN_CONSENSUS_ACTIVATION_H

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -69,13 +69,17 @@ static constexpr Amount DEFAULT_MIN_RELAY_TX_FEE_PER_KB(1000 * SATOSHI);
 /**
  * When transactions fail script evaluations under standard flags, this flagset
  * influences the decision of whether to drop them or to also ban the originator
- * (see CheckInputScripts).
+ * (see CheckInputScripts). Unused in Dogecoin, kept for tests.
  */
 static constexpr uint32_t MANDATORY_SCRIPT_VERIFY_FLAGS{
     SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC |
     SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_VERIFY_LOW_S |
     SCRIPT_VERIFY_NULLFAIL | SCRIPT_VERIFY_MINIMALDATA |
     SCRIPT_ENABLE_SCHNORR_MULTISIG | SCRIPT_ENFORCE_SIGCHECKS};
+
+/** Dogecoin: Mandatory script flags */
+static constexpr uint32_t MANDATORY_SCRIPT_VERIFY_FLAGS_LEGACY{
+    SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_LEGACY_RULES};
 
 /**
  * Standard script verification flags that standard transactions will comply
@@ -87,6 +91,8 @@ static constexpr uint32_t MANDATORY_SCRIPT_VERIFY_FLAGS{
  * restrictive flag set that applies in the current / next upgrade, since it is
  * used in numerous parts of the codebase that are unable to access the
  * contextual information of which upgrades are currently active.
+ *
+ * Unused in Dogecoin, kept for tests.
  */
 static constexpr uint32_t STANDARD_SCRIPT_VERIFY_FLAGS{
     MANDATORY_SCRIPT_VERIFY_FLAGS | SCRIPT_VERIFY_DERSIG |
@@ -95,11 +101,26 @@ static constexpr uint32_t STANDARD_SCRIPT_VERIFY_FLAGS{
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | SCRIPT_VERIFY_CHECKSEQUENCEVERIFY |
     SCRIPT_DISALLOW_SEGWIT_RECOVERY | SCRIPT_VERIFY_INPUT_SIGCHECKS};
 
+/** Dogecoin: Standard script flags */
+static constexpr uint32_t STANDARD_SCRIPT_VERIFY_FLAGS_LEGACY{
+    MANDATORY_SCRIPT_VERIFY_FLAGS_LEGACY | SCRIPT_VERIFY_DERSIG |
+    SCRIPT_VERIFY_STRICTENC | SCRIPT_VERIFY_MINIMALDATA |
+    SCRIPT_VERIFY_NULLDUMMY | SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
+    SCRIPT_VERIFY_CLEANSTACK | SCRIPT_VERIFY_MINIMALIF |
+    SCRIPT_VERIFY_NULLFAIL | SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY |
+    SCRIPT_VERIFY_CHECKSEQUENCEVERIFY | SCRIPT_VERIFY_LOW_S |
+    SCRIPT_DISALLOW_SEGWIT_RECOVERY};
+
 /**
  * For convenience, standard but not mandatory verify flags.
  */
 static constexpr uint32_t STANDARD_NOT_MANDATORY_VERIFY_FLAGS{
     STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS};
+
+/** Dogecoin: Standard non-mandatory flags */
+static constexpr uint32_t STANDARD_NOT_MANDATORY_VERIFY_FLAGS_LEGACY{
+    STANDARD_SCRIPT_VERIFY_FLAGS_LEGACY &
+    ~MANDATORY_SCRIPT_VERIFY_FLAGS_LEGACY};
 
 /**
  * Used as the flags parameter to sequence and nLocktime checks in non-consensus

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -117,6 +117,11 @@ BasicTestingSetup::BasicTestingSetup(
     fs::create_directories(m_path_root);
     m_args.ForceSetArg("-datadir", fs::PathToString(m_path_root));
     gArgs.ForceSetArg("-datadir", fs::PathToString(m_path_root));
+
+    // Dogecoin: Disable legacy (Dogecoin) script rules to not break all tests
+    m_args.ForceSetArg("-legacyscriptrules", "0");
+    gArgs.ForceSetArg("-legacyscriptrules", "0");
+
     gArgs.ClearPathCache();
     {
         SetupServerArgs(m_node);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -239,13 +239,6 @@ static bool IsReplayProtectionEnabled(const Consensus::Params &params,
     return IsReplayProtectionEnabled(params, pindexPrev->GetMedianTimePast());
 }
 
-// Command-line argument "-legacyscriptrules" will make the node enforce the old
-// script rules (see SCRIPT_VERIFY_LEGACY_RULES).
-static bool IsLegacyScriptRulesEnabled(const Consensus::Params &params) {
-    return gArgs.GetBoolArg("-legacyscriptrules",
-                            params.enforceLegacyScriptRules);
-}
-
 /**
  * Checks to avoid mempool polluting consensus critical paths since cached
  * signature and script validity results will be reused if we validate this
@@ -653,8 +646,13 @@ bool MemPoolAccept::PreChecks(ATMPArgs &args, Workspace &ws) {
     }
 
     // Validate input scripts against standard script flags.
-    const uint32_t scriptVerifyFlags =
-        ws.m_next_block_script_verify_flags | STANDARD_SCRIPT_VERIFY_FLAGS;
+    uint32_t scriptVerifyFlags = ws.m_next_block_script_verify_flags;
+    if (IsLegacyScriptRulesEnabled(
+            args.m_config.GetChainParams().GetConsensus())) {
+        scriptVerifyFlags |= STANDARD_SCRIPT_VERIFY_FLAGS_LEGACY;
+    } else {
+        scriptVerifyFlags |= STANDARD_SCRIPT_VERIFY_FLAGS;
+    }
     ws.m_precomputed_txdata = PrecomputedTransactionData{tx};
     if (!CheckInputScripts(tx, state, m_view, scriptVerifyFlags, true, false,
                            ws.m_precomputed_txdata, ws.m_sig_checks_standard)) {
@@ -1485,8 +1483,12 @@ bool CheckInputScripts(const CTransaction &tx, TxValidationState &state,
             // This differs from MANDATORY_SCRIPT_VERIFY_FLAGS as it contains
             // additional upgrade flags (see AcceptToMemoryPoolWorker variable
             // extraFlags).
-            uint32_t mandatoryFlags =
-                flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS;
+            uint32_t mandatoryFlags = flags;
+            if (flags & SCRIPT_VERIFY_LEGACY_RULES) {
+                mandatoryFlags &= ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS_LEGACY;
+            } else {
+                mandatoryFlags &= ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS;
+            }
             if (flags != mandatoryFlags) {
                 // Check whether the failure was caused by a non-mandatory
                 // script verification check. If so, ensure we return
@@ -1693,6 +1695,13 @@ static uint32_t GetNextBlockScriptFlags(const CBlockIndex *pindex,
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
     }
 
+    // If we are on a legacy network (i.e. Dogecoin), keep the old Script rules,
+    // and don't add any BCH/XEC script flags.
+    if (IsLegacyScriptRulesEnabled(consensusparams)) {
+        flags |= SCRIPT_VERIFY_LEGACY_RULES;
+        return flags;
+    }
+
     // If the UAHF is enabled, we start accepting replay protected txns
     if (IsUAHFenabled(consensusparams, pindex)) {
         flags |= SCRIPT_VERIFY_STRICTENC;
@@ -1730,11 +1739,6 @@ static uint32_t GetNextBlockScriptFlags(const CBlockIndex *pindex,
     // fork.
     if (IsReplayProtectionEnabled(consensusparams, pindex)) {
         flags |= SCRIPT_ENABLE_REPLAY_PROTECTION;
-    }
-
-    // If we are on a legacy network (i.e. Dogecoin), keep the old Script rules
-    if (IsLegacyScriptRulesEnabled(consensusparams)) {
-        flags |= SCRIPT_VERIFY_LEGACY_RULES;
     }
 
     return flags;

--- a/test/functional/feature_legacy_script_flags.py
+++ b/test/functional/feature_legacy_script_flags.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2024 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test Dogecoin's old script flags via -legacyscriptrules."""
+
+from test_framework.address import (
+    ADDRESS_ECREG_P2SH_OP_TRUE,
+    ADDRESS_ECREG_UNSPENDABLE,
+    SCRIPTSIG_OP_TRUE,
+)
+from test_framework.blocktools import (
+    create_block,
+    create_coinbase,
+    make_conform_to_ctor,
+)
+from test_framework.key import ECKey
+from test_framework.messages import COutPoint, CTransaction, CTxIn, CTxOut
+from test_framework.p2p import P2PDataStore
+from test_framework.script import (
+    OP_CHECKMULTISIG,
+    OP_CHECKSIG,
+    OP_ENDIF,
+    OP_EQUAL,
+    OP_HASH160,
+    OP_IF,
+    OP_NOP,
+    OP_RETURN,
+    OP_TRUE,
+    CScript,
+    SignatureHash,
+    SignatureHashForkId,
+    hash160,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.txtools import pad_tx
+from test_framework.util import assert_raises_rpc_error
+
+
+class LegacyScriptRulesTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [["-legacyscriptrules"], []]
+
+    def run_test(self):
+        node = self.nodes[0]
+        peer = node.add_p2p_connection(P2PDataStore())
+        nonlegacy_node = self.nodes[1]
+        nonlegacy_peer = nonlegacy_node.add_p2p_connection(P2PDataStore())
+
+        coinblockhash = self.generatetoaddress(node, 1, ADDRESS_ECREG_P2SH_OP_TRUE)[0]
+        cointxid = node.getblock(coinblockhash)["tx"][0]
+
+        self.generatetoaddress(node, 99, ADDRESS_ECREG_UNSPENDABLE)
+
+        def p2sh(opcodes):
+            return CScript([OP_HASH160, hash160(CScript(opcodes)), OP_EQUAL])
+
+        def make_block_with_txs(node, txs):
+            [tx.rehash() for tx in txs]
+            block = create_block(
+                int(node.getbestblockhash(), 16),
+                create_coinbase(node.getblockcount() + 1),
+            )
+            block.nVersion = 4
+            block.vtx += txs
+            make_conform_to_ctor(block)
+            block.hashMerkleRoot = block.calc_merkle_root()
+            block.solve()
+            return block
+
+        def check_mined_txs_fail(node, peer, txs, reject_reason):
+            block = make_block_with_txs(node, txs)
+            peer.send_blocks_and_test(
+                [block],
+                node,
+                success=False,
+                reject_reason=reject_reason,
+                expect_disconnect=True,
+            )
+            node.disconnect_p2ps()
+            return node.add_p2p_connection(P2PDataStore())
+
+        def check_mined_txs_success(node, peer, txs):
+            block = make_block_with_txs(node, txs)
+            peer.send_blocks_and_test([block], node)
+
+        # Flags on XEC that are not on Dogecoin:
+        # Mandatory flags:
+        # - SCRIPT_ENABLE_SIGHASH_FORKID
+        # - SCRIPT_ENABLE_SCHNORR_MULTISIG
+        # - SCRIPT_ENFORCE_SIGCHECKS (not tested here)
+        # Standard flags:
+        # - SCRIPT_VERIFY_SIGPUSHONLY
+
+        # Flags on Dogecoin that are not on XEC:
+        # Mandatory flags:
+        # - SCRIPT_VERIFY_LEGACY_RULES (tested in feature_legacy_script_rules)
+        # Standard flags:
+        # - SCRIPT_VERIFY_NULLDUMMY
+        # - SCRIPT_VERIFY_MINIMALIF
+
+        coinvalue = 5000000000
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(cointxid, 16), 0), SCRIPTSIG_OP_TRUE)]
+        tx.vout = [
+            CTxOut(2000, p2sh([OP_CHECKSIG])),
+            CTxOut(2000, p2sh([OP_CHECKMULTISIG])),
+            CTxOut(2000, p2sh([OP_IF, OP_ENDIF])),
+            CTxOut(2000, CScript([OP_TRUE])),
+            CTxOut(coinvalue - 20000, p2sh([OP_TRUE])),
+        ]
+        tx.rehash()
+        txid = tx.hash
+
+        # Fork both nodes, CLEANSTACK not enforced on Dogecoin
+        tx_noncleanstack = CTransaction()
+        tx_noncleanstack.vin = [
+            CTxIn(COutPoint(int(txid, 16), 4), CScript([b"jonny", CScript([OP_TRUE])]))
+        ]
+        pad_tx(tx_noncleanstack)
+
+        check_mined_txs_success(node, peer, [tx, tx_noncleanstack])
+
+        nonlegacy_peer = check_mined_txs_fail(
+            nonlegacy_node,
+            nonlegacy_peer,
+            [tx, tx_noncleanstack],
+            "blk-bad-inputs, parallel script check failed",
+        )
+        check_mined_txs_success(nonlegacy_node, nonlegacy_peer, [tx])
+
+        private_key = ECKey()
+        private_key.set(b"FGsltwthghobStwbihsnpbhel316....", True)
+        public_key = private_key.get_pubkey().get_bytes()
+
+        script = CScript([OP_CHECKSIG])
+        tx_sighash = CTransaction()
+        tx_sighash.vin = [CTxIn(COutPoint(int(txid, 16), 0))]
+        pad_tx(tx_sighash)
+
+        sighash = SignatureHashForkId(script, tx_sighash, 0, 0x41, 2000)
+        txsig = private_key.sign_ecdsa(sighash) + b"\x41"
+        tx_sighash_bip143 = CTransaction(tx_sighash)
+        tx_sighash_bip143.vin[0].scriptSig = CScript([txsig, public_key, script])
+
+        (sighash, _) = SignatureHash(script, tx_sighash, 0, 0x01)
+        txsig = private_key.sign_ecdsa(sighash) + b"\x01"
+        tx_sighash_legacy = CTransaction(tx_sighash)
+        tx_sighash_legacy.vin[0].scriptSig = CScript([txsig, public_key, script])
+
+        # SIGHASH_FORKID not allowed on Dogecoin
+        assert_raises_rpc_error(
+            -26,
+            "mandatory-script-verify-flag-failed (Illegal use of SIGHASH_FORKID)",
+            node.sendrawtransaction,
+            tx_sighash_bip143.serialize().hex(),
+        )
+        peer = check_mined_txs_fail(
+            node,
+            peer,
+            [tx_sighash_bip143],
+            "blk-bad-inputs, parallel script check failed",
+        )
+
+        # Legacy sighash not allowed on XEC
+        assert_raises_rpc_error(
+            -26,
+            "mandatory-script-verify-flag-failed (Signature must use SIGHASH_FORKID)",
+            nonlegacy_node.sendrawtransaction,
+            tx_sighash_legacy.serialize().hex(),
+        )
+        nonlegacy_peer = check_mined_txs_fail(
+            nonlegacy_node,
+            nonlegacy_peer,
+            [tx_sighash_legacy],
+            "blk-bad-inputs, parallel script check failed",
+        )
+
+        # Legacy sighash ok on Dogecoin
+        node.sendrawtransaction(tx_sighash_legacy.serialize().hex())
+        check_mined_txs_success(node, peer, [tx_sighash_legacy])
+
+        # SIGHASH_FORKID ok on XEC
+        nonlegacy_node.sendrawtransaction(tx_sighash_bip143.serialize().hex())
+        check_mined_txs_success(nonlegacy_node, nonlegacy_peer, [tx_sighash_bip143])
+
+        # Nulldummy enforced on Dogecoin, on XEC it's a bitfield
+        tx_nulldummy = CTransaction()
+        tx_nulldummy.vin = [
+            CTxIn(
+                COutPoint(int(txid, 16), 1),
+                CScript([20, b"sig", 1, public_key, 1, CScript([OP_CHECKMULTISIG])]),
+            )
+        ]
+        tx_nulldummy.vout = [CTxOut(0, CScript([OP_RETURN]))]
+        assert_raises_rpc_error(
+            -26,
+            "mandatory-script-verify-flag-failed (Dummy CHECKMULTISIG argument must be zero)",
+            node.sendrawtransaction,
+            tx_nulldummy.serialize().hex(),
+        )
+        peer = check_mined_txs_fail(
+            node, peer, [tx_nulldummy], "blk-bad-inputs, parallel script check failed"
+        )
+        assert_raises_rpc_error(
+            -26,
+            "mandatory-script-verify-flag-failed (Bitfield's bit out of the expected range)",
+            nonlegacy_node.sendrawtransaction,
+            tx_nulldummy.serialize().hex(),
+        )
+        nonlegacy_peer = check_mined_txs_fail(
+            nonlegacy_node,
+            nonlegacy_peer,
+            [tx_nulldummy],
+            "blk-bad-inputs, parallel script check failed",
+        )
+
+        # MINIMALIF enforced on Dogecoin, not on XEC
+        tx_minimalif = CTransaction()
+        tx_minimalif.vin = [
+            CTxIn(
+                COutPoint(int(txid, 16), 2),
+                CScript([OP_TRUE, 1337, CScript([OP_IF, OP_ENDIF])]),
+            )
+        ]
+        pad_tx(tx_minimalif)
+        assert_raises_rpc_error(
+            -26,
+            "mandatory-script-verify-flag-failed (OP_IF/NOTIF argument must be minimal)",
+            node.sendrawtransaction,
+            tx_minimalif.serialize().hex(),
+        )
+        # Allowed in blocks in Dogecoin
+        check_mined_txs_success(node, peer, [tx_minimalif])
+        # Always allowed on XEC
+        nonlegacy_node.sendrawtransaction(tx_minimalif.serialize().hex())
+        check_mined_txs_success(nonlegacy_node, nonlegacy_peer, [tx_minimalif])
+
+        # Non-push opcodes allowed in scriptSigs on Dogecoin in blocks
+        tx_signonpush = CTransaction()
+        tx_signonpush.vin = [CTxIn(COutPoint(int(txid, 16), 3), CScript([OP_NOP]))]
+        pad_tx(tx_signonpush)
+        check_mined_txs_success(node, peer, [tx_signonpush])
+        # Disallowed on XEC
+        nonlegacy_peer = check_mined_txs_fail(
+            nonlegacy_node,
+            nonlegacy_peer,
+            [tx_signonpush],
+            "blk-bad-inputs, parallel script check failed",
+        )
+
+
+if __name__ == "__main__":
+    LegacyScriptRulesTest().main()


### PR DESCRIPTION
Dogecoin has different verify flags, resulting in different enforcement rules for the mempool.

Also enable all the legacy rules on regtest when -legacyscriptrules is enabled, not just those ones under SCRIPT_VERIFY_LEGACY_RULES.