### PR TITLE
[Chronik] Fix: Use actual CBlockHeader in GetFirstBlockTxOffset

### DIFF
--- a/chronik/chronik-cpp/chronik_bridge.cpp
+++ b/chronik/chronik-cpp/chronik_bridge.cpp
@@ -103,7 +103,7 @@ chronik_bridge::BlockTx BridgeBlockTx(bool isCoinbase, const CTransaction &tx,
 }
 
 size_t GetFirstBlockTxOffset(const CBlock &block, const CBlockIndex &bindex) {
-    return bindex.nDataPos + ::GetSerializeSize(CBlockHeader()) +
+    return bindex.nDataPos + ::GetSerializeSize(block.GetBlockHeader()) +
            GetSizeOfCompactSize(block.vtx.size());
 }
 


### PR DESCRIPTION
Currently, `GetFirstBlockTxOffset` results in wrong values for AuxPow (which are longer than 80 bytes), resulting in bad data_pos values.