### PR TITLE
Add `MakeVersionWithChainId` and `VersionWithAuxPow`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -553,6 +553,7 @@ add_library(common
 	netbase.cpp
 	outputtype.cpp
 	policy/policy.cpp
+	primitives/auxpow.cpp
 	primitives/baseheader.cpp
 	primitives/block.cpp
 	protocol.cpp

--- a/src/primitives/auxpow.cpp
+++ b/src/primitives/auxpow.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#include <primitives/auxpow.h>
+#include <stdexcept>
+#include <tinyformat.h>
+
+int32_t MakeVersionWithChainId(uint32_t nChainId, uint32_t nLowVersionBits) {
+    // Ensure nChainId and nLowVersionBits are in a valid range
+    if (nLowVersionBits >= VERSION_AUXPOW_BIT) {
+        throw std::invalid_argument(
+            strprintf("nLowVersionBits out of range: 0x%x >= 0x%x",
+                      nLowVersionBits, VERSION_AUXPOW_BIT));
+    }
+    if (nChainId > MAX_ALLOWED_CHAIN_ID) {
+        throw std::invalid_argument(
+            strprintf("nChainId out of range: 0x%x > 0x%x", nChainId,
+                      MAX_ALLOWED_CHAIN_ID));
+    }
+    return (nChainId << VERSION_CHAIN_ID_BIT_POS) | nLowVersionBits;
+}
+
+int32_t VersionWithAuxPow(uint32_t nVersion, bool hasAuxPow) {
+    if (hasAuxPow) {
+        return nVersion | VERSION_AUXPOW_BIT;
+    } else {
+        return nVersion & ~VERSION_AUXPOW_BIT;
+    }
+}

--- a/src/primitives/auxpow.h
+++ b/src/primitives/auxpow.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_PRIMITIVES_AUXPOW_H
+#define BITCOIN_PRIMITIVES_AUXPOW_H
+
+#include <cstdint>
+
+/** Bit that indicates a block has auxillary PoW. Bits below that are
+ * interpreted as the "traditional" Bitcoin version. */
+static constexpr int32_t VERSION_AUXPOW_BIT_POS = 8;
+static constexpr int32_t VERSION_AUXPOW_BIT = 1 << VERSION_AUXPOW_BIT_POS;
+
+/** Position of the bits reserved for the auxpow chain ID. */
+static constexpr int32_t VERSION_CHAIN_ID_BIT_POS = 16;
+
+/** Chain ID used by Dogecoin. */
+static constexpr int32_t AUXPOW_CHAIN_ID = 0x62;
+
+/** Max allowed chain ID */
+static constexpr uint32_t MAX_ALLOWED_CHAIN_ID =
+    (1 << (32 - VERSION_CHAIN_ID_BIT_POS)) - 1;
+
+/**
+ * Build version bits from the given parameters, with AuxPow disabled.
+ * @param nChainId The auxpow chain ID.
+ * @param nLowVersionBits The low version bits below the AuxPow flag.
+ */
+int32_t MakeVersionWithChainId(uint32_t nChainId, uint32_t nLowVersionBits);
+
+/**
+ * Set the AuxPow flag bit in the nVersion.
+ * @param nVersion A block's nVersion.
+ * @param hasAuxPow Whether the AuxPow flag should be set.
+ */
+int32_t VersionWithAuxPow(uint32_t nVersion, bool hasAuxPow);
+
+#endif // BITCOIN_PRIMITIVES_AUXPOW_H

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -171,6 +171,7 @@ add_boost_unit_tests_to_suite(bitcoin test_bitcoin
 		denialofservice_tests.cpp
 		descriptor_tests.cpp
 		dnsseeds_tests.cpp
+		dogecoin_block_version_tests.cpp
 		dstencode_tests.cpp
 		feerate_tests.cpp
 		flatfile_tests.cpp

--- a/src/test/dogecoin_block_version_tests.cpp
+++ b/src/test/dogecoin_block_version_tests.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <primitives/auxpow.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(dogecoin_block_version_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(MakeVersionWithChainId_test) {
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(0, 0), 0);
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(1, 0), 0x10000);
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(AUXPOW_CHAIN_ID, 0), 0x620000);
+
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(0, 0xab), 0xab);
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(1, 0xab), 0x100ab);
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(AUXPOW_CHAIN_ID, 0xab), 0x6200ab);
+
+    // nChainId is validated
+    BOOST_CHECK_EQUAL(MakeVersionWithChainId(MAX_ALLOWED_CHAIN_ID, 0),
+                      0xffff0000);
+    BOOST_CHECK_THROW(MakeVersionWithChainId(MAX_ALLOWED_CHAIN_ID + 1, 0),
+                      std::invalid_argument);
+    BOOST_CHECK_THROW(MakeVersionWithChainId(0x70000000, 0),
+                      std::invalid_argument);
+    BOOST_CHECK_THROW(MakeVersionWithChainId(0x10000, 0x100),
+                      std::invalid_argument);
+
+    // nLowVersionBits is validated
+    BOOST_CHECK_THROW(MakeVersionWithChainId(0, 0x100), std::invalid_argument);
+    BOOST_CHECK_THROW(MakeVersionWithChainId(0, 0x70000000),
+                      std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(VersionWithAuxPow_test) {
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0, false), 0);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x100, false), 0);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xab, false), 0xab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x1ab, false), 0xab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x620000, false), 0x620000);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x620100, false), 0x620000);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x6200ab, false), 0x6200ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x6201ab, false), 0x6200ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xffff00ab, false), 0xffff00ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xffff01ab, false), 0xffff00ab);
+
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0, true), 0x100);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x100, true), 0x100);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xab, true), 0x1ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x1ab, true), 0x1ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x620000, true), 0x620100);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x620100, true), 0x620100);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x6200ab, true), 0x6201ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0x6201ab, true), 0x6201ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xffff00ab, true), 0xffff01ab);
+    BOOST_CHECK_EQUAL(VersionWithAuxPow(0xffff01ab, true), 0xffff01ab);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These functions build the nVersion with the correct bits set for aux PoW used in merge-mining.