### PR TITLE
[DogeCash] Fix feature_legacy_script_flags.py

### DIFF
--- a/test/functional/feature_legacy_script_flags.py
+++ b/test/functional/feature_legacy_script_flags.py
@@ -258,7 +258,9 @@ class LegacyScriptRulesTest(BitcoinTestFramework):
             "blk-bad-inputs, parallel script check failed",
         )
 
-        # Test SIGHASH_FORKID with legacy signatures
+        # Test borked SIGHASH_FORKID with legacy signatures
+        # On Dogecoin, signatures with SIGHASH_FORKID are valid if found in
+        # blocks and if legacy signatures are used. Bork = fork + bug
         script = CScript([OP_CHECKSIG])
         tx_sighash_bork = CTransaction()
         pad_tx(tx_sighash_bork)


### PR DESCRIPTION
Fix the test so it tests the correct script flag (and sighash type) behavior.

This test was written under the assumption that there are more mandatory script flags on Dogecoin, however, the only one is SCRIPT_VERIFY_P2SH.

Somehow this test was merged (probably by having the wrong script flags first, then implementing the test, and later fixing the script flags without fixing the test), so we fix it here.