### PR TITLE
[DogeCash] Speed up header presync/sync using a faster GetPowHash

### DIFF
--- a/src/primitives/baseheader.cpp
+++ b/src/primitives/baseheader.cpp
@@ -14,6 +14,7 @@ BlockHash CBaseBlockHeader::GetHash() const {
 }
 
 BlockHash CBaseBlockHeader::GetPowHash() const {
+    // TODO: Dedup serialization, e.g. using a SpanWriter
     uint8_t bytes[80];
     size_t idx = 0;
     uint32_t version = this->nVersion;


### PR DESCRIPTION
Currently, GetPowHash allocates, which slows down the hash calculation. This is unnecessary and removing this speeds up the header presync/sync.