### PR TITLE
[DogeCash] Parallelize PoW check

### DIFF
--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -315,6 +315,7 @@ epilogue:
         chainman.m_load_block.join();
     }
     StopScriptCheckWorkerThreads();
+    StopPowCheckWorkerThreads();
 
     GetMainSignals().FlushBackgroundCallbacks();
     {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -279,6 +279,7 @@ void Shutdown(NodeContext &node) {
         node.chainman->m_load_block.join();
     }
     StopScriptCheckWorkerThreads();
+    StopPowCheckWorkerThreads();
 
     // After the threads that potentially access these pointers have been
     // stopped, destruct and reset all to nullptr.
@@ -2137,6 +2138,7 @@ bool AppInitMain(Config &config, RPCServer &rpcServer,
               script_threads);
     if (script_threads >= 1) {
         StartScriptCheckWorkerThreads(script_threads);
+        StartPowCheckWorkerThreads(script_threads);
     }
 
     assert(!node.scheduler);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -221,6 +221,7 @@ ChainTestingSetup::ChainTestingSetup(
 
     constexpr int script_check_threads = 2;
     StartScriptCheckWorkerThreads(script_check_threads);
+    StartPowCheckWorkerThreads(script_check_threads);
 }
 
 ChainTestingSetup::~ChainTestingSetup() {
@@ -228,6 +229,7 @@ ChainTestingSetup::~ChainTestingSetup() {
         m_node.scheduler->stop();
     }
     StopScriptCheckWorkerThreads();
+    StopPowCheckWorkerThreads();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     m_node.connman.reset();

--- a/src/validation.h
+++ b/src/validation.h
@@ -157,11 +157,13 @@ public:
  * Run instances of script checking worker threads
  */
 void StartScriptCheckWorkerThreads(int threads_num);
+void StartPowCheckWorkerThreads(int threads_num);
 
 /**
  * Stop all of the script checking worker threads
  */
 void StopScriptCheckWorkerThreads();
+void StopPowCheckWorkerThreads();
 
 Amount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams,
                        uint256 prevHash);


### PR DESCRIPTION
On Dogecoin, the PoW check is very expensive, which slows down the (on Bitcoin, quite fast) header pre-sync and sync.

Instead of running PoW checks sequentially, we run them in parallel using the same worker queue as for the script checks.