### PR TITLE
[dogd] Rebrand to dogd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,10 @@ set(CMAKE_USER_MAKE_RULES_OVERRIDE
 	"${CMAKE_SOURCE_DIR}/cmake/modules/OverrideInitFlags.cmake"
 )
 
-project(dogecash
+project(dogd
 	VERSION 0.1.0
-	DESCRIPTION "Dogecash is a full node implementation of the Dogecoin protocol."
-	HOMEPAGE_URL "https://www.dogecash.io"
+	DESCRIPTION "dogd is a full node implementation of the Dogecoin protocol."
+	HOMEPAGE_URL "https://www.dogd.io"
 )
 
 add_custom_target(print-version
@@ -23,8 +23,8 @@ add_custom_target(print-project-name
 )
 
 # Package information
-set(PACKAGE_NAME "Dogecash")
-set(PACKAGE_BUGREPORT "https://github.com/dogecash-io/dogecash/issues")
+set(PACKAGE_NAME "dogd")
+set(PACKAGE_BUGREPORT "https://github.com/dogd-io/dogd/issues")
 
 # Copyright
 set(COPYRIGHT_YEAR 2024)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-Contributing to Dogecash
+Contributing to dogd
 ========================
 
-The Dogecash project welcomes contributors!
+The dogd project welcomes contributors!
 
-This guide is intended to help developers contribute effectively to Dogecash.
+This guide is intended to help developers contribute effectively to dogd.
 
 Communicating with Developers
 -----------------------------
 
-To get in contact with Dogecash developers, you can join the
+To get in contact with dogd developers, you can join the
 [eCash Development Telegram group](https://t.me/eCashDevelopment).
 The intent of this group is to facilitate development of Bitcoin ABC and other
 eCash node implementations. We welcome people who wish to participate.
@@ -24,10 +24,10 @@ It is not for:
 * Market discussion
 * Non-constructive criticism
 
-Dogecash Development Philosophy
+dogd Development Philosophy
 -------------------------------
 
-Dogecash aims for fast iteration and continuous integration.
+dogd aims for fast iteration and continuous integration.
 
 This means that there should be quick turnaround for patches to be proposed,
 reviewed, and committed. Changes should not sit in a queue for long.
@@ -59,7 +59,7 @@ quickly, it should be reverted, and re-applied later when it no longer breaks th
 top priority, more important than completing other tasks.
 - Automate as much as possible, and spend time on things only humans can do.
 
-Here are some handy links for development practices aligned with Dogecash:
+Here are some handy links for development practices aligned with dogd:
 
 - [Developer Notes](doc/developer-notes.md)
 - [Statement of Bitcoin ABC Values and Visions](https://archive.md/ulgFI)
@@ -84,7 +84,7 @@ Contributing to the node software
 ---------------------------------
 
 During submission of patches, arcanist will automatically run `arc lint` to
-enforce Dogecash code formatting standards, and often suggests changes.
+enforce dogd code formatting standards, and often suggests changes.
 If code formatting tools do not install automatically on your system, you
 will have to install the following:
 
@@ -140,7 +140,7 @@ to install `nodejs` with node version manager.
 Then:
 
 ```
-cd dogecash
+cd dogd
 [sudo] nvm install 20
 [sudo] npm install -g npm@latest
 [sudo] npm install -g prettier@2.6.0
@@ -151,7 +151,7 @@ Some repositories have a `.nvmrc` file which specifies the version of node expec
 For example, to work in Cashtab,
 
 ```
-cd dogecash/cashtab
+cd dogd/cashtab
 nvm use
 ```
 

--- a/DISCLOSURE_POLICY.md
+++ b/DISCLOSURE_POLICY.md
@@ -1,10 +1,10 @@
 # Responsible Disclosure Policy
 
-Dogecash takes security very seriously.  We greatly appreciate any and all disclosures of bugs and vulnerabilities that are done in a responsible manner.  We will engage responsible disclosures according to this policy and put forth our best effort to fix disclosed vulnerabilities as well as reaching out to numerous node operators to deploy fixes in a timely manner.
+dogd takes security very seriously.  We greatly appreciate any and all disclosures of bugs and vulnerabilities that are done in a responsible manner.  We will engage responsible disclosures according to this policy and put forth our best effort to fix disclosed vulnerabilities as well as reaching out to numerous node operators to deploy fixes in a timely manner.
 
 ## Responsible Disclosure Guidelines
 
-Do not disclose any bug or vulnerability on public forums, message boards, mailing lists, etc. prior to responsibly disclosing to Dogecash and giving sufficient time for the issue to be fixed and deployed.
+Do not disclose any bug or vulnerability on public forums, message boards, mailing lists, etc. prior to responsibly disclosing to dogd and giving sufficient time for the issue to be fixed and deployed.
 Do not execute on or exploit any vulnerability.  This includes testnet, as both mainnet and testnet exploits are effectively public disclosure.  Regtest mode may be used to test bugs locally.
 
 ## Reporting a Bug or Vulnerability
@@ -17,11 +17,11 @@ When reporting a bug or vulnerability, please provide the following to tobias.ru
 
 ## Disclosure Relationships
 
-Neighboring projects that may be affected by bugs, potential exploits, or other security vulnerabilities that are disclosed to Dogecash will be passed along information regarding disclosures that we believe could impact them.  We are disclosing these relationships here:
+Neighboring projects that may be affected by bugs, potential exploits, or other security vulnerabilities that are disclosed to dogd will be passed along information regarding disclosures that we believe could impact them.  We are disclosing these relationships here:
 
 * [Bitcoin ABC](https://bitcoinabc.org/)
   * [Disclosure Policy](https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/DISCLOSURE_POLICY.md)
 
 ## Bounty Payments
 
-Dogecash cannot commit to bounty payments ahead of time.  However, we will use our best judgement and do intend on rewarding those who provide valuable disclosures (with a strong emphasis on easy to read and reproduce disclosures).
+dogd cannot commit to bounty payments ahead of time.  However, we will use our best judgement and do intend on rewarding those who provide valuable disclosures (with a strong emphasis on easy to read and reproduce disclosures).

--- a/PackageOptions.cmake
+++ b/PackageOptions.cmake
@@ -4,7 +4,7 @@ set(CPACK_PACKAGE_DESCRIPTION "${PROJECT_DESCRIPTION}")
 set(CPACK_PACKAGE_HOMEPAGE_URL "${PROJECT_HOMEPAGE_URL}")
 set(CPACK_PACKAGE_CONTACT "tobias.ruck@be.cash")
 
-set(CPACK_PACKAGE_INSTALL_DIRECTORY "Dogecash")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "dogd")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/COPYING")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/doc/README_windows.txt")
 
@@ -57,7 +57,7 @@ macro(add_start_menu_link LINK_NAME EXE PARAMETERS ICON_EXE ICON_INDEX)
 	)
 endmacro()
 
-set(CPACK_NSIS_MENU_LINKS "${CMAKE_INSTALL_BINDIR}/${_nsis_bitcoin_qt}" "Dogecash")
+set(CPACK_NSIS_MENU_LINKS "${CMAKE_INSTALL_BINDIR}/${_nsis_bitcoin_qt}" "dogd")
 add_start_menu_link("${PACKAGE_NAME} (testnet)"
 	"${_nsis_bitcoin_qt}"
 	"-testnet"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![Dogecash Logo](share/pixmaps/bitcoinabclogo.png "Dogecash")](https://www.dogecash.io)
+[![dogd Logo](share/pixmaps/bitcoinabclogo.png "dogd")](https://www.dogd.io)
 
-Dogecash is a high performance full node implementation for Dogecoin.
+dogd is a high performance full node implementation for Dogecoin.
 
-Dogecash is not a new blockchain. It is an alternative node implementation that
+dogd is not a new blockchain. It is an alternative node implementation that
 is 100% compatible with Dogecoin.
 
-The goal of Dogecash is to create sound money that is usable by everyone in
+The goal of dogd is to create sound money that is usable by everyone in
 the world. This is a civilization-changing technology which will dramatically
 increase human flourishing, freedom, and prosperity. The project aims to
 achieve this goal by implementing a series of optimizations and protocol
@@ -24,12 +24,12 @@ What is Bitcoin ABC?
 
 Bitcoin ABC is the name of open-source software which enables the use of
 eCash. It is a fork of the [Bitcoin Core](https://bitcoincore.org)
-software project. Dogecash is a fork of Bitcoin ABC.
+software project. dogd is a fork of Bitcoin ABC.
 
 License
 -------
 
-Dogecash is released under the terms of the MIT license. See
+dogd is released under the terms of the MIT license. See
 [COPYING](COPYING) for more information or see
 <https://opensource.org/licenses/MIT>.
 

--- a/cmake/modules/NSIS.template.in
+++ b/cmake/modules/NSIS.template.in
@@ -53,9 +53,9 @@ Var StartMenuGroup
 # Installer attributes
 OutFile "@CPACK_TOPLEVEL_DIRECTORY@/@CPACK_OUTPUT_FILE_NAME@"
 !if "@CPACK_SYSTEM_NAME@" == "x86_64-w64-mingw32"
-InstallDir $PROGRAMFILES64\Dogecash
+InstallDir $PROGRAMFILES64\dogd
 !else
-InstallDir $PROGRAMFILES\Dogecash
+InstallDir $PROGRAMFILES\dogd
 !endif
 CRCCheck on
 XPStyle on
@@ -108,7 +108,7 @@ Section -post SEC0001
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "URL Protocol" ""
-    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:Dogecash"
+    WriteRegStr HKCR "@CPACK_PACKAGE_NAME@" "" "URL:dogd"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\DefaultIcon" "" "$INSTDIR\${BITCOIN_GUI_NAME}"
     WriteRegStr HKCR "@CPACK_PACKAGE_NAME@\shell\open\command" "" '"$INSTDIR\${BITCOIN_GUI_NAME}" "%1"'
 SectionEnd
@@ -141,7 +141,7 @@ Section -un.post UNSEC0001
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\Uninstall $(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\$(^Name).lnk"
     Delete /REBOOTOK "$SMPROGRAMS\$StartMenuGroup\@CPACK_NSIS_DISPLAY_NAME@ (testnet).lnk"
-    Delete /REBOOTOK "$SMSTARTUP\Dogecash.lnk"
+    Delete /REBOOTOK "$SMSTARTUP\dogd.lnk"
     Delete /REBOOTOK "$INSTDIR\uninstall.exe"
     Delete /REBOOTOK "$INSTDIR\debug.log"
     Delete /REBOOTOK "$INSTDIR\db.log"

--- a/cmake/templates/version.rc.in
+++ b/cmake/templates/version.rc.in
@@ -18,7 +18,7 @@ BEGIN
     BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
-            VALUE "CompanyName",        "Dogecash"
+            VALUE "CompanyName",        "dogd"
             VALUE "FileDescription",    "${DESCRIPTION}"
             VALUE "FileVersion",        VER_FILEVERSION_STR
             VALUE "InternalName",       "${NAME}"

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -23,7 +23,7 @@ Contains files used to package dogecoind/dogecoin-qt
 for Debian-based Linux systems. If you compile dogecoind/dogecoin-qt yourself, there are some useful files here.
 
 ### [Signing](/contrib/signing)
-PGP keys used for signing Dogecash [release](/doc/release-process.md) results.
+PGP keys used for signing dogd [release](/doc/release-process.md) results.
 
 ### [MacDeploy](/contrib/macdeploy) ###
 Scripts and notes for Mac builds.

--- a/contrib/aur/bitcoin-abc-qt/PKGBUILD
+++ b/contrib/aur/bitcoin-abc-qt/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=bitcoin-abc-qt
 pkgver=0.30.5
 pkgrel=0
-pkgdesc="Dogecash with dogecoind, dogecoin-cli, dogecoin-tx, dogecoin-seeder and dogecoin-qt"
+pkgdesc="dogd with dogecoind, dogecoin-cli, dogecoin-tx, dogecoin-seeder and dogecoin-qt"
 arch=('i686' 'x86_64')
 url="https://bitcoinabc.org"
 depends=('boost-libs' 'libevent' 'desktop-file-utils' 'qt5-base' 'protobuf' 'openssl' 'miniupnpc' 'libnatpmp' 'zeromq' 'qrencode' 'jemalloc')

--- a/contrib/aur/bitcoin-abc/PKGBUILD
+++ b/contrib/aur/bitcoin-abc/PKGBUILD
@@ -3,7 +3,7 @@
 pkgname=bitcoin-abc
 pkgver=0.30.5
 pkgrel=0
-pkgdesc="Dogecash with dogecoind, dogecoin-tx, dogecoin-seeder and dogecoin-cli"
+pkgdesc="dogd with dogecoind, dogecoin-tx, dogecoin-seeder and dogecoin-cli"
 arch=('i686' 'x86_64')
 url="https://bitcoinabc.org"
 depends=('boost-libs' 'libevent' 'openssl' 'zeromq' 'miniupnpc' 'libnatpmp' 'jemalloc')

--- a/contrib/aur/common/bitcoin.install
+++ b/contrib/aur/common/bitcoin.install
@@ -35,7 +35,7 @@ _rmuser() {
 
 read -d '' bitcoin <<'EOI'
 
-Dogecash
+dogd
 ___________
 
 To start bitcoin-abc:
@@ -44,8 +44,8 @@ $ systemctl start bitcoin
 
 To communicate with bitcoin-abc as a normal user:
 
-$ mkdir -p ~/.dogecash
-$ cat > ~/.dogecash/dogecoin.conf <<'EOF'
+$ mkdir -p ~/.dogd
+$ cat > ~/.dogd/dogecoin.conf <<'EOF'
 rpcport=22555
 rpcuser=bitcoin
 rpcpassword=secret

--- a/contrib/debian/bitcoin-qt.desktop
+++ b/contrib/debian/bitcoin-qt.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=Dogecash
+Name=dogd
 Comment=Connect to the Bitcoin P2P Network
 Comment[de]=Verbinde mit dem Bitcoin peer-to-peer Netzwerk
 Comment[fr]=Bitcoin, monnaie virtuelle cryptographique pair à pair

--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -1,7 +1,7 @@
 Source: bitcoinabc
 Section: utils
 Priority: optional
-Maintainer: Dogecash Package Maintainers <package-maintainers@bitcoinabc.org>
+Maintainer: dogd Package Maintainers <package-maintainers@bitcoinabc.org>
 Uploaders: Jason B. Cox <jasonbcox@bitcoinabc.org>
 Build-Depends: cmake (>= 3.16),
  debhelper (>=12.1),
@@ -38,7 +38,7 @@ Description: peer-to-peer network based digital currency - daemon
  Bitcoin is an experimental new digital currency that enables instant
  payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
  technology to operate with no central authority: managing transactions
- and issuing money are carried out collectively by the network. Dogecash
+ and issuing money are carried out collectively by the network. dogd
  is the name of the open source software which enables the use of this currency.
  .
  This package provides the daemon, dogecoind, and the CLI tool
@@ -51,7 +51,7 @@ Description: peer-to-peer network based digital currency - Qt GUI
  Bitcoin is an experimental new digital currency that enables instant
  payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
  technology to operate with no central authority: managing transactions
- and issuing money are carried out collectively by the network. Dogecash
+ and issuing money are carried out collectively by the network. dogd
  is the name of the open source software which enables the use of this currency.
  .
  This package provides Dogecoin-Qt, a GUI for Bitcoin based on Qt.
@@ -63,7 +63,7 @@ Description: peer-to-peer digital currency - standalone transaction tool
  Bitcoin is an experimental new digital currency that enables instant
  payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
  technology to operate with no central authority: managing transactions
- and issuing money are carried out collectively by the network. Dogecash
+ and issuing money are carried out collectively by the network. dogd
  is the name of the open source software which enables the use of this currency.
  .
  This package provides dogecoin-tx, a command-line transaction creation
@@ -77,8 +77,8 @@ Description: peer-to-peer digital currency - wallet tool
  Bitcoin is an experimental new digital currency that enables instant
  payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer
  technology to operate with no central authority: managing transactions
- and issuing money are carried out collectively by the network. Dogecash
+ and issuing money are carried out collectively by the network. dogd
  is the name of the open source software which enables the use of this currency.
  .
  This package provides dogecoin-wallet, an offline tool for creating and
- interacting with Dogecash wallet files.
+ interacting with dogd wallet files.

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -1,5 +1,5 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Dogecash
+Upstream-Name: dogd
 Upstream-Contact: helpdesk@bitcoinabc.org
 Source: https://github.com/Bitcoin-ABC/bitcoin-abc
 

--- a/contrib/devtools/bitcoind-exit-on-log.sh
+++ b/contrib/devtools/bitcoind-exit-on-log.sh
@@ -9,14 +9,14 @@ trap "kill 0" SIGINT
 
 TOPLEVEL=$(git rev-parse --show-toplevel)
 DEFAULT_BITCOIND="${TOPLEVEL}/build/src/dogecoind"
-DEFAULT_LOG_FILE=~/".dogecash/debug.log"
+DEFAULT_LOG_FILE=~/".dogd/debug.log"
 
 help_message() {
   set +x
   echo "Run dogecoind until a given log message is encountered, then kill dogecoind."
   echo ""
   echo "Example usages:"
-  echo "$0 --grep 'progress=1.000000' --params \"-datadir=~/.dogecash\" --callback mycallback"
+  echo "$0 --grep 'progress=1.000000' --params \"-datadir=~/.dogd\" --callback mycallback"
   echo ""
   echo "Options:"
   echo "-h, --help            Display this help message."

--- a/contrib/devtools/chainparams/make_chainparams.py
+++ b/contrib/devtools/chainparams/make_chainparams.py
@@ -99,10 +99,10 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config",
         "-c",
-        default="~/.dogecash/dogecoin.conf",
+        default="~/.dogd/dogecoin.conf",
         help=(
             "Path to dogecoin.conf for RPC authentication arguments (rpcuser &"
-            " rpcpassword).\nDefault: ~/.dogecash/dogecoin.conf"
+            " rpcpassword).\nDefault: ~/.dogd/dogecoin.conf"
         ),
     )
     args = parser.parse_args()

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -1,4 +1,4 @@
-# Bootstrappable Dogecash Builds
+# Bootstrappable dogd Builds
 
 This directory contains the files necessary to perform bootstrappable Bitcoin
 ABC builds.
@@ -57,7 +57,7 @@ and examples](#common-guix-build-invocation-patterns-and-examples) section below
 before starting a build. For a full list of customization options, see the
 [recognized environment variables][env-vars-list] section.*
 
-To build Dogecash reproducibly with all default options, invoke the
+To build dogd reproducibly with all default options, invoke the
 following from the top of a clean repository:
 
 ```sh

--- a/contrib/guix/guix-build
+++ b/contrib/guix/guix-build
@@ -152,7 +152,7 @@ done
 if (( total_required_KiB > avail_KiB )); then
     total_required_GiB=$((total_required_KiB / 1048576))
     avail_GiB=$((avail_KiB / 1048576))
-    echo "Performing a Dogecash Guix build for the selected HOSTS requires ${total_required_GiB} GiB, however, only ${avail_GiB} GiB is available. Please free up some disk space before performing the build."
+    echo "Performing a dogd Guix build for the selected HOSTS requires ${total_required_GiB} GiB, however, only ${avail_GiB} GiB is available. Please free up some disk space before performing the build."
     exit 1
 fi
 

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -389,7 +389,7 @@ EOF
         exit 1
     fi
 
-    # Build Dogecash
+    # Build dogd
     ninja
     ninja security-check
     ninja symbol-check

--- a/contrib/guix/manifest.scm
+++ b/contrib/guix/manifest.scm
@@ -107,7 +107,7 @@ chain for " target " development."))
                                        (base-libc glibc-2.28)
                                        (base-gcc linux-base-gcc))
   "Convenience wrapper around MAKE-CROSS-TOOLCHAIN with default values
-desirable for building Dogecash release binaries."
+desirable for building dogd release binaries."
   (make-cross-toolchain target
                         base-gcc-for-libc
                         base-kernel-headers

--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -2,8 +2,8 @@
 
 # backward compatibility for existing gentoo layout
 #
-if [ -d "/var/lib/bitcoin/.dogecash" ]; then
-	BITCOIND_DEFAULT_DATADIR="/var/lib/bitcoin/.dogecash"
+if [ -d "/var/lib/bitcoin/.dogd" ]; then
+	BITCOIND_DEFAULT_DATADIR="/var/lib/bitcoin/.dogd"
 else
 	BITCOIND_DEFAULT_DATADIR="/var/lib/dogecoind"
 fi
@@ -18,7 +18,7 @@ BITCOIND_BIN=${BITCOIND_BIN:-/usr/bin/dogecoind}
 BITCOIND_NICE=${BITCOIND_NICE:-${NICELEVEL:-0}}
 BITCOIND_OPTS="${BITCOIND_OPTS:-${BITCOIN_OPTS}}"
 
-name="Dogecash Daemon"
+name="dogd Daemon"
 description="Bitcoin cryptocurrency P2P network daemon"
 
 command="/usr/bin/dogecoind"

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -3,10 +3,10 @@ Description=eCash node
 After=network.target
 
 [Service]
-ExecStart=%h/bitcoin-abc/bin/dogecoind -daemonwait -conf=%h/.dogecash/dogecoin.conf -pid=%h/.dogecash/dogecoind.pid
-ExecStopPost=-/bin/bash -c 'mv %h/.dogecash/debug.log %h/.dogecash/debug_$(date +%%Y%%m%%d%%H%%M%%S).log'
+ExecStart=%h/bitcoin-abc/bin/dogecoind -daemonwait -conf=%h/.dogd/dogecoin.conf -pid=%h/.dogd/dogecoind.pid
+ExecStopPost=-/bin/bash -c 'mv %h/.dogd/debug.log %h/.dogd/debug_$(date +%%Y%%m%%d%%H%%M%%S).log'
 Type=forking
-PIDFile=%h/.dogecash/dogecoind.pid
+PIDFile=%h/.dogd/dogecoind.pid
 Restart=unless-stopped
 RestartSec=5
 StartLimitInterval=10

--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -1,7 +1,7 @@
 # dogecoind RPC settings (linearize-hashes)
 rpcuser=someuser
 rpcpassword=somepassword
-#datadir=~/.dogecash
+#datadir=~/.dogd
 host=127.0.0.1
 
 #mainnet default
@@ -21,12 +21,12 @@ max_height=313000
 # mainnet
 netmagic=f9beb4d9
 genesis=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-input=/home/example/.dogecash/blocks
+input=/home/example/.dogd/blocks
 
 # testnet
 #netmagic=0b110907
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
-#input=/home/example/.dogecash/testnet3/blocks
+#input=/home/example/.dogd/testnet3/blocks
 
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.

--- a/contrib/message-capture/message-capture-docs.md
+++ b/contrib/message-capture/message-capture-docs.md
@@ -8,7 +8,7 @@ This feature allows for message capture on a per-peer basis.  It answers the sim
 
 * Run `dogecoind` with the `-capturemessages` option.
 * Look in the `message_capture` folder in your datadir.
-  * Typically this will be `~/.dogecash/message_capture`.
+  * Typically this will be `~/.dogd/message_capture`.
   * See that there are many folders inside, one for each peer names with its IP address and port.
   * Inside each peer's folder there are two `.dat` files: one is for received messages (`msgs_recv.dat`) and the other is for sent messages (`msgs_sent.dat`).
 * Run `contrib/message-capture/message-capture-parser.py` with the proper arguments.
@@ -16,7 +16,7 @@ This feature allows for message capture on a per-peer basis.  It answers the sim
   * To see all messages, both sent and received, for all peers use:
     ```
     ./contrib/message-capture/message-capture-parser.py -o out.json \
-    ~/.dogecash/message_capture/**/*.dat
+    ~/.dogd/message_capture/**/*.dat
     ```
   * Note:  The messages in the given `.dat` files will be interleaved in chronological order.  So, giving both received and sent `.dat` files (as above with `*.dat`) will result in all messages being interleaved in chronological order.
   * If an output file is not provided (i.e. the `-o` option is not used), then the output prints to `stdout`.

--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -9,7 +9,7 @@ changes its default return value, as those are the services which seeds are adde
 to addrman with).
 
 The seeds compiled into the release are created from the `dnsseed.dump` output file of a
-[Dogecash Seeder](/src/seeder) that has been running for at least 30 days. The scripts
+[dogd Seeder](/src/seeder) that has been running for at least 30 days. The scripts
 below assume that the `dnsseed.dump` file from the mainnet seeder has been copied to
 `seeds_main.txt` and the `dnsseed.dump` file from the testnet seeder has been copied to
 `seeds_test.txt`.

--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -26,8 +26,8 @@ PATTERN_IPV4 = re.compile(r"^((\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})):(\d+)$
 PATTERN_IPV6 = re.compile(r"^\[([0-9a-z:]+)\]:(\d+)$")
 PATTERN_ONION = re.compile(r"^([abcdefghijklmnopqrstuvwxyz234567]{16}\.onion):(\d+)$")
 
-# Used to only select nodes with a user agent string compatible with Dogecash.
-PATTERN_AGENT = re.compile(r"^(/Dogecash:0\.(1)\.(.+)/)")
+# Used to only select nodes with a user agent string compatible with dogd.
+PATTERN_AGENT = re.compile(r"^(/dogd:0\.(1)\.(.+)/)")
 
 
 def parseline(line: str) -> Union[dict, None]:

--- a/contrib/teamcity/build-configurations.yml
+++ b/contrib/teamcity/build-configurations.yml
@@ -325,7 +325,7 @@ builds:
       src/bench/BitcoinABC_Bench.json: bench/BitcoinABC_Bench.json
     post_build: |
       "${TOPLEVEL}/contrib/teamcity/nanobench_json_to_teamcity_messages.py" \
-        "Dogecash Benchmark" \
+        "dogd Benchmark" \
         "${BUILD_DIR}/src/bench/BitcoinABC_Bench.json"
 
   build-chronik:

--- a/contrib/tracing/README.md
+++ b/contrib/tracing/README.md
@@ -2,8 +2,8 @@ Example scripts for User-space, Statically Defined Tracing (USDT)
 =================================================================
 
 This directory contains scripts showcasing User-space, Statically Defined
-Tracing (USDT) support for Dogecash on Linux using. For more information on
-USDT support in Dogecash see the [USDT documentation].
+Tracing (USDT) support for dogd on Linux using. For more information on
+USDT support in dogd see the [USDT documentation].
 
 [USDT documentation]: ../../doc/tracing.md
 
@@ -34,10 +34,10 @@ The bpftrace examples contain a relative path to the `dogecoind` binary. By
 default, the scripts should be run from the repository-root and assume a
 self-compiled `dogecoind` binary. The paths in the examples can be changed, for
 example, to point to release builds if needed. See the
-[Dogecash USDT documentation] on how to list available tracepoints in your
+[dogd USDT documentation] on how to list available tracepoints in your
 `dogecoind` binary.
 
-[Dogecash USDT documentation]: ../../doc/tracing.md#listing-available-tracepoints
+[dogd USDT documentation]: ../../doc/tracing.md#listing-available-tracepoints
 
 **WARNING: eBPF programs require root privileges to be loaded into a Linux
 kernel VM. This means the bpftrace and BCC examples must be executed with root
@@ -184,7 +184,7 @@ longer than 25ms to connect.
 $ bpftrace contrib/tracing/connectblock_benchmark.bt 20000 38000 25
 ```
 
-In a different terminal, starting Dogecash in Testnet mode and with
+In a different terminal, starting dogd in Testnet mode and with
 re-indexing enabled.
 
 ```

--- a/depends/README.md
+++ b/depends/README.md
@@ -24,7 +24,7 @@ Note that it will use all the CPU cores available on the machine by default.
 This behavior can be changed by setting the `JOBS` environment variable (see
 below).
 
-To use the dependencies for building Dogecash, you need to set the platform
+To use the dependencies for building dogd, you need to set the platform
 file to be used by `cmake`.
 The platform files are located under `cmake/platforms/`.
 For example, cross-building for macOS (run from the project root):

--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -29,7 +29,7 @@ dogecoin-cli -named createwallet mywallet load_on_startup=true
 
 ## Versioning
 
-The RPC interface might change from one major version of Dogecash to the
+The RPC interface might change from one major version of dogd to the
 next. This makes the RPC interface implicitly versioned on the major version.
 The version tuple can be retrieved by e.g. the `getnetworkinfo` RPC in
 `version`.
@@ -41,21 +41,21 @@ were deprecated and how to re-enable them temporarily.
 
 ## Security
 
-The RPC interface allows other programs to control Dogecash,
+The RPC interface allows other programs to control dogd,
 including the ability to spend funds from your wallets, affect consensus
 verification, read private data, and otherwise perform operations that
 can cause loss of money, data, or privacy.  This section suggests how
-you should use and configure Dogecash to reduce the risk that its
+you should use and configure dogd to reduce the risk that its
 RPC interface will be abused.
 
 - **Securing the executable:** Anyone with physical or remote access to
-  the computer, container, or virtual machine running Dogecash can
+  the computer, container, or virtual machine running dogd can
   compromise either the whole program or just the RPC interface.  This
   includes being able to record any passphrases you enter for unlocking
-  your encrypted wallets or changing settings so that your Dogecash
+  your encrypted wallets or changing settings so that your dogd
   program tells you that certain transactions have multiple
   confirmations even when they aren't part of the best block chain.  For
-  this reason, you should not use Dogecash for security sensitive
+  this reason, you should not use dogd for security sensitive
   operations on systems you do not exclusively control, such as shared
   computers or virtual private servers.
 
@@ -65,19 +65,19 @@ RPC interface will be abused.
   and passphrase).  Any program on your computer with access to the file
   system and local network can obtain this level of access.
   Additionally, other programs on your computer can attempt to provide
-  an RPC interface on the same port as used by Dogecash in order to
+  an RPC interface on the same port as used by dogd in order to
   trick you into revealing your authentication credentials.  For this
-  reason, it is important to only use Dogecash for
+  reason, it is important to only use dogd for
   security-sensitive operations on a computer whose other programs you
   trust.
 
 - **Securing remote network access:** You may optionally allow other
-  computers to remotely control Dogecash by setting the `rpcallowip`
+  computers to remotely control dogd by setting the `rpcallowip`
   and `rpcbind` configuration parameters.  These settings are only meant
   for enabling connections over secure private networks or connections
   that have been otherwise secured (e.g. using a VPN or port forwarding
   with SSH or stunnel).  **Do not enable RPC connections over the public
-  Internet.**  Although Dogecash's RPC interface does use
+  Internet.**  Although dogd's RPC interface does use
   authentication, it does not use encryption, so your login credentials
   are sent as clear text that can be read by anyone on your network
   path.  Additionally, the RPC interface has not been hardened to
@@ -87,21 +87,21 @@ RPC interface will be abused.
   `dogecoind -help` for more information about these settings and other
   settings described in this document.
 
-    Related, if you use Dogecash inside a Docker container, you may
+    Related, if you use dogd inside a Docker container, you may
     need to expose the RPC port to the host system.  The default way to
     do this in Docker also exposes the port to the public Internet.
     Instead, expose it only on the host system's localhost, for example:
     `-p 127.0.0.1:22555:22555`
 
-- **Secure authentication:** By default, Dogecash generates unique
+- **Secure authentication:** By default, dogd generates unique
   login credentials each time it restarts and puts them into a file
-  readable only by the user that started Dogecash, allowing any of
+  readable only by the user that started dogd, allowing any of
   that user's RPC clients with read access to the file to login
-  automatically.  The file is `.cookie` in the Dogecash
+  automatically.  The file is `.cookie` in the dogd
   configuration directory, and using these credentials is the preferred
   RPC authentication method.  If you need to generate static login
   credentials for your programs, you can use the script in the
-  `share/rpcauth` directory in the Dogecash source tree.  As a final
+  `share/rpcauth` directory in the dogd source tree.  As a final
   fallback, you can directly use manually-chosen `rpcuser` and
   `rpcpassword` configuration parameters---but you must ensure that you
   choose a strong and unique passphrase (and still don't use insecure

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,11 +1,11 @@
-Dogecash
+dogd
 =====================
 
 Setup
 ---------------------
-Dogecash is a fork of Bitcoin Core, which is the original Bitcoin client and builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions, which requires a few hundred gigabytes of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
+dogd is a fork of Bitcoin Core, which is the original Bitcoin client and builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions, which requires a few hundred gigabytes of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download Dogecash, visit [bitcoinabc.org](https://download.bitcoinabc.org/).
+To download dogd, visit [bitcoinabc.org](https://download.bitcoinabc.org/).
 
 Verify
 ---------------------
@@ -45,7 +45,7 @@ the presence of those warnings should be heeded with extreme caution.
 
 Running
 ---------------------
-The following are some helpful notes on how to run Dogecash on your native platform.
+The following are some helpful notes on how to run dogd on your native platform.
 
 ### Unix
 
@@ -66,11 +66,11 @@ Drag bitcoin-abc to your applications folder, and then run bitcoin-abc.
 
 * See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
 for help and more information.
-* Ask for help on the [Dogecash Subreddit](https://www.reddit.com/r/BitcoinABC/).
+* Ask for help on the [dogd Subreddit](https://www.reddit.com/r/BitcoinABC/).
 
 Building
 ---------------------
-The following are developer notes on how to build Dogecash on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+The following are developer notes on how to build dogd on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
 
 - [Dependencies](dependencies.md)
 - [macOS Build Notes](build-osx.md)
@@ -80,7 +80,7 @@ The following are developer notes on how to build Dogecash on your native platfo
 
 Development
 ---------------------
-The Dogecash repo's [root README](/README.md) contains relevant information on the development process and automated testing.
+The dogd repo's [root README](/README.md) contains relevant information on the development process and automated testing.
 
 - [Developer Notes](developer-notes.md)
 - [Productivity Notes](productivity.md)

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Dogecash
+dogd
 =====================
 
 Intro
@@ -13,7 +13,7 @@ Setup
 -----
 Unpack the files into a directory and run dogecoin-qt.exe.
 
-Dogecash is based on Bitcoin Core, which is the original Bitcoin client and
+dogd is based on Bitcoin Core, which is the original Bitcoin client and
 builds the backbone of the network. It downloads and stores the entire history
 of Bitcoin transactions; depending on the speed of your computer and network
 connection, the synchronization process can take anywhere from a few hours to

--- a/doc/backporting.md
+++ b/doc/backporting.md
@@ -1,9 +1,9 @@
 BACKPORTING
 ===========
 
-The official Dogecash guide to backporting code from Bitcoin Core. When searching
+The official dogd guide to backporting code from Bitcoin Core. When searching
 for items to backport, especially be on the lookout for bug fixes, code cleanup, and
-important refactors, as these help improve Dogecash despite consensus-level differences
+important refactors, as these help improve dogd despite consensus-level differences
 between eCash and Bitcoin Core.
 
 Identifying commits
@@ -11,7 +11,7 @@ Identifying commits
 
 1. Check out a copy of a Satoshi Bitcoin client somewhere on your machine.
 2. Identify the subsystem you'd like to work on.
-3. Tag the fork commit as `fork-commit`. Dogecash was forked from Bitcoin Core
+3. Tag the fork commit as `fork-commit`. dogd was forked from Bitcoin Core
    at commit `964a185cc83af34587194a6ecda3ed9cf6b49263`.
    `> git tag -a fork-commit 964a185 -m 'Where the fun started'`
 4. `git log --topo-order --graph fork-commit..HEAD -- <file or folder of interest>`
@@ -46,7 +46,7 @@ easier.  Backports are easiest done in topological order of commits.
 Backporting
 -----------
 
-Before you begin backporting commits, you will need to add an additional remote to your Dogecash repo.
+Before you begin backporting commits, you will need to add an additional remote to your dogd repo.
 For Bitcoin Core, this repository would be added as:
 
 ```
@@ -97,7 +97,7 @@ Squash the commits together for backporting
 Backporting from secp256k1, Electrum and Electron Cash
 ------------------------------------------------------
 
-The Dogecash monorepo includes subprojects that are stored in subdirectories of the main repository.
+The dogd monorepo includes subprojects that are stored in subdirectories of the main repository.
 To backport commits for these subprojects, you can add the corresponding additional remotes and use the
 `-Xsubtree` option for `git cherry-pick`.
 

--- a/doc/benchmarking.md
+++ b/doc/benchmarking.md
@@ -1,7 +1,7 @@
 Benchmarking
 ============
 
-Dogecash has an internal benchmarking framework, with benchmarks
+dogd has an internal benchmarking framework, with benchmarks
 for cryptographic algorithms (e.g. SHA1, SHA256, SHA512, RIPEMD160),
 as well as the rolling bloom filter, address encoding and decoding,
 CCoinsCaching, memory pool eviction, and wallet coin selection.

--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -47,7 +47,7 @@ rpcport=4000
 
 ## Configuration File Path
 
-The configuration file is not automatically created; you can create it using your favorite text editor. By default, the configuration file name is `dogecoin.conf` and it is located in the Dogecash data directory, but both the Dogecash data directory and the configuration file path may be changed using the `-datadir` and `-conf` command-line options.
+The configuration file is not automatically created; you can create it using your favorite text editor. By default, the configuration file name is `dogecoin.conf` and it is located in the dogd data directory, but both the dogd data directory and the configuration file path may be changed using the `-datadir` and `-conf` command-line options.
 
 The `includeconf=<file>` option in the `dogecoin.conf` file can be used to include additional configuration files.
 
@@ -55,8 +55,8 @@ The `includeconf=<file>` option in the `dogecoin.conf` file can be used to inclu
 
 Operating System | Data Directory | Example Path
 -- | -- | --
-Windows | `%APPDATA%\Dogecash\` | `C:\Users\username\AppData\Roaming\Dogecash\dogecoin.conf`
-Linux | `$HOME/.dogecash/` | `/home/username/.dogecash/dogecoin.conf`
-macOS | `$HOME/Library/Application Support/Dogecash/` | `/Users/username/Library/Application Support/Dogecash/dogecoin.conf`
+Windows | `%APPDATA%\dogd\` | `C:\Users\username\AppData\Roaming\dogd\dogecoin.conf`
+Linux | `$HOME/.dogd/` | `/home/username/.dogd/dogecoin.conf`
+macOS | `$HOME/Library/Application Support/dogd/` | `/Users/username/Library/Application Support/dogd/dogecoin.conf`
 
 You can find an example dogecoin.conf file in [contrib/debian/examples/dogecoin.conf](../contrib/debian/examples/dogecoin.conf).

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -30,19 +30,19 @@ If you want to build the disk image with `ninja osx-dmg` (.dmg / optional), you 
 
     brew install librsvg
 
-Build Dogecash
+Build dogd
 -----------------
 
 Before you start building, please make sure that your compiler supports C++17.
 
-1. Clone the Dogecash source code and cd into `bitcoin-abc`
+1. Clone the dogd source code and cd into `bitcoin-abc`
 
         git clone https://github.com/Bitcoin-ABC/bitcoin-abc.git
         cd bitcoin-abc
 
-2.  Build Dogecash:
+2.  Build dogd:
 
-    Configure and build the headless Dogecash binaries as well as the GUI.
+    Configure and build the headless dogd binaries as well as the GUI.
 
     You can disable the GUI build by passing `-DBUILD_BITCOIN_QT=OFF` to cmake.
 
@@ -63,7 +63,7 @@ Before you start building, please make sure that your compiler supports C++17.
 
 Disable-wallet mode
 --------------------
-When the intention is to run only a P2P node without a wallet, Dogecash may be compiled in
+When the intention is to run only a P2P node without a wallet, dogd may be compiled in
 disable-wallet mode with:
 
     cmake -GNinja .. -DBUILD_BITCOIN_WALLET=OFF
@@ -73,7 +73,7 @@ Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC 
 Running
 -------
 
-Dogecash is now available at `./src/dogecoind`
+dogd is now available at `./src/dogecoind`
 
 Before running, it's recommended that you create an RPC configuration file:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,6 +1,6 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Dogecash in Unix.
+Some notes on how to build dogd in Unix.
 
 To Build
 ---------------------
@@ -22,7 +22,7 @@ This will build dogecoin-qt as well.
 Dependencies
 ---------------------
 
-*Note: Dogecash provides a [Docker image with all the dependencies preinstalled](#build-using-a-docker-container).*
+*Note: dogd provides a [Docker image with all the dependencies preinstalled](#build-using-a-docker-container).*
 
 These dependencies are required:
 
@@ -54,7 +54,7 @@ Memory Requirements
 --------------------
 
 C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
-memory available when compiling Dogecash. On systems with less, gcc can be
+memory available when compiling dogd. On systems with less, gcc can be
 tuned to conserve memory with additional CXXFLAGS:
 
     cmake -GNinja .. -DCMAKE_CXX_FLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
@@ -106,7 +106,7 @@ BerkeleyDB 5.3 or later and SQLite 3.7 or later are required for the wallet. The
 
         sudo apt-get install libdb-dev libdb++-dev libsqlite3-dev
 
-See the section "Disable-wallet mode" to build Dogecash without wallet.
+See the section "Disable-wallet mode" to build dogd without wallet.
 
 Port mapping dependencies MiniUPnPc and NAT-PMP (can be disabled by passing `-DENABLE_UPNP=OFF` and `-DENABLE_NATPMP=OFF` on the cmake command line):
 
@@ -201,7 +201,7 @@ For documentation on building Boost look at their official documentation: http:/
 
 Security
 --------
-To help make your Dogecash installation more secure by making certain attacks impossible to
+To help make your dogd installation more secure by making certain attacks impossible to
 exploit even if a vulnerability is found, binaries are hardened by default.
 This can be disabled by passing `-DENABLE_HARDENING=OFF`.
 
@@ -225,7 +225,7 @@ Hardening enables the following features:
       ET_DYN
 
 * _Non-executable Stack_: If the stack is executable then trivial stack-based buffer overflow exploits are possible if
-    vulnerable buffers are found. By default, Dogecash should be built with a non-executable stack,
+    vulnerable buffers are found. By default, dogd should be built with a non-executable stack,
     but if one of the libraries it uses asks for an executable stack or someone makes a mistake
     and uses a compiler extension which requires an executable stack, it will silently build an
     executable without the non-executable stack protection.
@@ -243,7 +243,7 @@ Hardening enables the following features:
 
 Disable-wallet mode
 --------------------
-When the intention is to run only a P2P node without a wallet, Dogecash may be compiled in
+When the intention is to run only a P2P node without a wallet, dogd may be compiled in
 disable-wallet mode by passing `-DBUILD_BITCOIN_WALLET=OFF` on the cmake command line.
 
 Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
@@ -293,7 +293,7 @@ For further documentation on the depends system see [README.md](../depends/READM
 Build using a Docker container
 -------------------------------
 
-Dogecash provides a
+dogd provides a
 [Docker image](https://hub.docker.com/r/bitcoinabc/bitcoin-abc-dev) with all the
 dependencies pre-installed, based on Debian. If the dependencies cannot be
 installed on your system but it can run a Docker container, this image can be

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,12 +1,12 @@
 WINDOWS BUILD NOTES
 ====================
 
-Below are some notes on how to build Dogecash for Windows.
+Below are some notes on how to build dogd for Windows.
 
-The options known to work for building Dogecash on Windows are:
+The options known to work for building dogd on Windows are:
 
 * On Linux, using the [Mingw-w64](https://mingw-w64.org/doku.php) cross compiler tool chain. Debian Bullseye is recommended
-and is the platform used to build the Dogecash Windows release binaries.
+and is the platform used to build the dogd Windows release binaries.
 * On Windows, using [Windows
 Subsystem for Linux (WSL)](https://msdn.microsoft.com/commandline/wsl/about) and the Mingw-w64 cross compiler tool chain.
 
@@ -64,7 +64,7 @@ First, install the general dependencies:
     sudo apt upgrade
     sudo apt install autoconf automake build-essential bsdmainutils curl git libboost-dev libevent-dev libssl-dev libtool ninja-build pkg-config python3 python-pytest
 
-The cmake version packaged with Ubuntu Bionic is too old for building Building Dogecash.
+The cmake version packaged with Ubuntu Bionic is too old for building Building dogd.
 To install the latest version:
 
     sudo apt-get install apt-transport-https ca-certificates gnupg software-properties-common wget
@@ -104,7 +104,7 @@ Ubuntu Artful 17.10 <sup>[2](#footnote2)</sup> and later, including Ubuntu Bioni
 
 Once the toolchain is installed the build steps are common:
 
-Note that for WSL the Dogecash source path MUST be somewhere in the default mount file system, for
+Note that for WSL the dogd source path MUST be somewhere in the default mount file system, for
 example /usr/src/bitcoin-abc, AND not under /mnt/d/.
 This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
 
@@ -152,5 +152,5 @@ something break.
 options to allow a choice between either posix or win32 threads. The default option is win32 threads which is the more
 efficient since it will result in binary code that links directly with the Windows kernel32.lib. Unfortunately, the headers
 required to support win32 threads conflict with some of the classes in the C++11 standard library, in particular std::mutex.
-It's not possible to build the Dogecash code using the win32 version of the Mingw-w64 cross compilers (at least not without
-modifying headers in the Dogecash source code).
+It's not possible to build the dogd code using the win32 version of the Mingw-w64 cross compilers (at least not without
+modifying headers in the dogd source code).

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 Dependencies
 ============
 
-These are the dependencies currently used by Dogecash. You can find instructions for installing them in the [`build-*.md`](../INSTALL.md) file for your platform.
+These are the dependencies currently used by dogd. You can find instructions for installing them in the [`build-*.md`](../INSTALL.md) file for your platform.
 
 | Dependency | Version used | Minimum required | CVEs | Shared | [Bundled Qt library](https://doc.qt.io/qt-5/configure-options.html) |
 | --- | --- | --- | --- | --- | --- |

--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -1,6 +1,6 @@
-# Support for Output Descriptors in Dogecash
+# Support for Output Descriptors in dogd
 
-Since Dogecash v0.20.7, there is support for Output Descriptors. This is a
+Since dogd v0.20.7, there is support for Output Descriptors. This is a
 simple language which can be used to describe collections of output scripts.
 Supporting RPCs are:
 - `scantxoutset` takes as input descriptors to scan for, and also reports
@@ -174,7 +174,7 @@ steps, or for dumping wallet descriptors including private key material.
 ### Compatibility with old wallets
 
 In order to easily represent the sets of scripts currently supported by
-existing Dogecash wallets, a convenience function `combo` is provided,
+existing dogd wallets, a convenience function `combo` is provided,
 which takes as input a public key, and describes a set of P2PK and P2PKH
 scripts for that key.
 
@@ -190,7 +190,7 @@ be detected in descriptors up to 501 characters, and up to 3 errors in longer
 ones. For larger numbers of errors, or other types of errors, there is a
 roughly 1 in a trillion chance of not detecting the errors.
 
-All RPCs in Dogecash will include the checksum in their output. Only
+All RPCs in dogd will include the checksum in their output. Only
 certain RPCs require checksums on input, including `deriveaddress` and
 `importmulti`. The checksum for a descriptor without one can be computed
 using the `getdescriptorinfo` RPC.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -271,7 +271,7 @@ that run in `-regtest` mode.
 
 ### DEBUG_LOCKORDER
 
-Dogecash is a multi-threaded application, and deadlocks or other
+dogd is a multi-threaded application, and deadlocks or other
 multi-threading bugs can be very difficult to track down.
 The `-DCMAKE_BUILD_TYPE=Debug` cmake option adds `-DDEBUG_LOCKORDER` to the
 compiler flags. This inserts run-time checks to keep track of which locks are
@@ -401,7 +401,7 @@ See the functional test documentation for how to invoke perf within tests.
 
 ### Sanitizers
 
-Dogecash can be compiled with various "sanitizers" enabled, which add
+dogd can be compiled with various "sanitizers" enabled, which add
 instrumentation for issues regarding things like memory safety, thread race
 conditions, or undefined behavior. This is controlled with the
 `-DENABLE_SANITIZERS` cmake flag, which should be a semicolon separated list of
@@ -574,7 +574,7 @@ Ignoring IDE/editor files
 In closed-source environments in which everyone uses the same IDE it is common
 to add temporary files it produces to the project-wide `.gitignore` file.
 
-However, in open source software such as Dogecash, where everyone uses
+However, in open source software such as dogd, where everyone uses
 their own editors/IDE/tools, it is less common. Only you know what files your
 editor produces and this may change from version to version. The canonical way
 to do this is thus to create your local gitignore. Add this to `~/.gitconfig`:
@@ -604,7 +604,7 @@ Development guidelines
 ============================
 
 A few non-style-related recommendations for developers, as well as points to
-pay attention to for reviewers of Dogecash code.
+pay attention to for reviewers of dogd code.
 
 Wallet
 -------
@@ -962,7 +962,7 @@ Third party libraries
 Several parts of the repository are software maintained elsewhere.
 
 Changes to these should preferably be sent upstream but bugfixes may also be
-submitted to Dogecash so that they can be integrated quickly.
+submitted to dogd so that they can be integrated quickly.
 Cosmetic changes should be purely taken upstream.
 
 Current third party libraries include:
@@ -970,13 +970,13 @@ Current third party libraries include:
 - src/leveldb
   - Upstream at <https://github.com/google/leveldb> ; Maintained by Google.
   - **Note**: Follow the instructions in [Upgrading LevelDB](#upgrading-leveldb)
-    when merging upstream changes to Dogecash.
+    when merging upstream changes to dogd.
 
 - src/secp256k1
   - Upstream at <https://github.com/bitcoin-core/secp256k1/> ; actively maintained
     by Bitcoin Core contributors.
-    Dogecash is using a modified version of libsecp256k1, some changes might
-    be directly submitted to Dogecash.
+    dogd is using a modified version of libsecp256k1, some changes might
+    be directly submitted to dogd.
     See the [secp256k1 README](../src/secp256k1/README.md) for details.
 
 - src/crypto/ctaes
@@ -1026,7 +1026,7 @@ to check for issues affecting consensus compatibility.
 For example, if LevelDB had a bug that accidentally prevented a key from being
 returned in an edge case, and that bug was fixed upstream, the bug "fix" would
 be an incompatible consensus change. In this situation the correct behavior
-would be to revert the upstream fix before applying the updates to Dogecash's
+would be to revert the upstream fix before applying the updates to dogd's
 copy of LevelDB. In general you should be wary of any upstream changes affecting
 what data is returned from LevelDB queries.
 

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -1,7 +1,7 @@
-Dogecash BCH-relevant DNS seed information
+dogd BCH-relevant DNS seed information
 =============================================
 
-Dogecash uses special seeds under the control of Bitcoin Cash (BCH)
+dogd uses special seeds under the control of Bitcoin Cash (BCH)
 network supporting operators to increase the chance of a node
 to find suitable peers on the BCH network.
 

--- a/doc/doxygen/README.md
+++ b/doc/doxygen/README.md
@@ -2,8 +2,8 @@
 
 \section intro_sec Introduction
 
-This is the developer documentation of [Dogecash](https://www.bitcoinabc.org/).
-Dogecash is a client for the digital currency called [eCash](https://e.cash/),
+This is the developer documentation of [dogd](https://www.bitcoinabc.org/).
+dogd is a client for the digital currency called [eCash](https://e.cash/),
 which enables instant payments to anyone, anywhere in the world. eCash uses
 peer-to-peer technology to operate with no central authority: managing
 transactions and issuing money are carried out collectively by the network.

--- a/doc/files.md
+++ b/doc/files.md
@@ -1,4 +1,4 @@
-# Dogecash file system
+# dogd file system
 
 **Contents**
 
@@ -16,15 +16,15 @@
 
 ## Data directory location
 
-The data directory is the default location where the Dogecash files are stored.
+The data directory is the default location where the dogd files are stored.
 
 1. The default data directory paths for supported platforms are:
 
 Platform | Data directory path
 ---------|--------------------
-Linux    | `$HOME/.dogecash/`
-macOS    | `$HOME/Library/Application Support/Dogecash/`
-Windows  | `%APPDATA%\Dogecash\` <sup>[\[1\]](#note1)</sup>
+Linux    | `$HOME/.dogd/`
+macOS    | `$HOME/Library/Application Support/dogd/`
+Windows  | `%APPDATA%\dogd\` <sup>[\[1\]](#note1)</sup>
 
 2. The non-default data directory path can be specified by `-datadir` option.
 
@@ -92,7 +92,7 @@ Subdirectory | File(s)           | Description
 
 ## Legacy subdirectories and files
 
-These subdirectories and files are no longer used by the Dogecash:
+These subdirectories and files are no longer used by the dogd:
 
 Path           | Description | Repository notes
 ---------------|-------------|-----------------

--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -1,4 +1,4 @@
-Fuzz-testing Dogecash
+Fuzz-testing dogd
 ==========================
 
 A special test harness in `src/test/fuzz/` is provided for each fuzz target to
@@ -46,7 +46,7 @@ export AFLPATH=$PWD
 
 ### Instrumentation
 
-To build Dogecash using AFL instrumentation (this assumes that the
+To build dogd using AFL instrumentation (this assumes that the
 `AFLPATH` was set as above):
 ```
 mkdir -p buildFuzzer
@@ -131,7 +131,7 @@ This version has no support for the `lld` linker so you need to add
 
 Should you run into problems with the address sanitizer, it is possible you
 may need to run `cmake` with `-DCRYPTO_USE_ASM=OFF` to avoid errors with
-certain assembly code from Dogecash's code.
+certain assembly code from dogd's code.
 See [developer notes on sanitizers](developer-notes.md#sanitizers) for more
 information.
 

--- a/doc/i2p.md
+++ b/doc/i2p.md
@@ -1,20 +1,20 @@
-# I2P support in Dogecash
+# I2P support in dogd
 
-It is possible to run Dogecash as an
+It is possible to run dogd as an
 [I2P (Invisible Internet Project)](https://en.wikipedia.org/wiki/I2P)
 service and connect to such services.
 
 This [glossary](https://geti2p.net/en/about/glossary) may be useful to get
 started with I2P terminology.
 
-## Run Dogecash with an I2P router (proxy)
+## Run dogd with an I2P router (proxy)
 
 A running I2P router (proxy) with [SAM](https://geti2p.net/en/docs/api/samv3)
 enabled is required (there is an [official one](https://geti2p.net) and
 [a few alternatives](https://en.wikipedia.org/wiki/I2P#Routers)). Notice the IP
 address and port the SAM proxy is listening to; usually, it is
 `127.0.0.1:7656`. Once it is up and running with SAM enabled, use the following
-Dogecash options:
+dogd options:
 
 ```
 -i2psam=<ip:port>
@@ -36,9 +36,9 @@ In a typical situation, this suffices:
 dogecoind -i2psam=127.0.0.1:7656
 ```
 
-The first time Dogecash connects to the I2P router, its I2P address (and
+The first time dogd connects to the I2P router, its I2P address (and
 corresponding private key) will be automatically generated and saved in a file
-named `i2p_private_key` in the Dogecash data directory.
+named `i2p_private_key` in the dogd data directory.
 
 ## Additional configuration options related to I2P
 
@@ -47,15 +47,15 @@ information in the debug log about your I2P configuration and connections. Run
 `dogecoin-cli help logging` for more information.
 
 It is possible to restrict outgoing connections in the usual way with
-`onlynet=i2p`. I2P support was added to Dogecash in version 22.0 (mid 2021)
+`onlynet=i2p`. I2P support was added to dogd in version 22.0 (mid 2021)
 and there may be fewer I2P peers than Tor or IP ones. Therefore, using
 `onlynet=i2p` alone (without other `onlynet=`) may make a node more susceptible
 to [Sybil attacks](https://en.bitcoin.it/wiki/Weaknesses#Sybil_attack). Use
 `dogecoin-cli -addrinfo` to see the number of I2P addresses known to your node.
 
-## I2P related information in Dogecash
+## I2P related information in dogd
 
-There are several ways to see your I2P address in Dogecash:
+There are several ways to see your I2P address in dogd:
 - in the debug log (grep for `AddLocal`, the I2P address ends in `.b32.i2p`)
 - in the output of the `getnetworkinfo` RPC in the "localaddresses" section
 - in the output of `dogecoin-cli -netinfo` peer connections dashboard
@@ -68,20 +68,20 @@ RPC.
 
 ## Compatibility
 
-Dogecash uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3) protocol
+dogd uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3) protocol
 to connect to the I2P network. Any I2P router that supports it can be used.
 
-## Ports in I2P and Dogecash
+## Ports in I2P and dogd
 
-Dogecash uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3)
+dogd uses the [SAM v3.1](https://geti2p.net/en/docs/api/samv3)
 protocol. One particularity of SAM v3.1 is that it does not support ports,
 unlike newer versions of SAM (v3.2 and up) that do support them and default the
 port numbers to 0. From the point of view of peers that use newer versions of
 SAM or other protocols that support ports, a SAM v3.1 peer is connecting to them
 on port 0, from source port 0.
 
-To allow future upgrades to newer versions of SAM, Dogecash sets its
+To allow future upgrades to newer versions of SAM, dogd sets its
 listening port to 0 when listening for incoming I2P connections and advertises
 its own I2P address with port 0. Furthermore, it will not attempt to connect to
 I2P addresses with a non-zero port number because with SAM v3.1 the destination
-port (`TO_PORT`) is always set to 0 and is not in the control of Dogecash.
+port (`TO_PORT`) is always set to 0 and is not in the control of dogd.

--- a/doc/linters.md
+++ b/doc/linters.md
@@ -1,7 +1,7 @@
 Linters
 =======
 
-The Dogecash project makes heavy use of linters to ensure consistency between
+The dogd project makes heavy use of linters to ensure consistency between
 the various source files and prevent some common issues. A list of all the
 linters can be found in the `.arclint` file at the root of the project.
 

--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -1,14 +1,14 @@
-When Dogecash automatically opens outgoing P2P connections it chooses
+When dogd automatically opens outgoing P2P connections it chooses
 a peer (address and port) from its list of potential peers. This list is
 populated with unchecked data, gossiped over the P2P network by other peers.
 
-A malicious actor may gossip an address:port where no Dogecash node is
+A malicious actor may gossip an address:port where no dogd node is
 listening, or one where a service is listening that is not related to the eCash
 network. As a result, this service may occasionally get connection attempts from
-Dogecash nodes.
+dogd nodes.
 
 "Bad" ports are ones used by services which are usually not open to the public
-and usually require authentication. A connection attempt (by Dogecash, trying
+and usually require authentication. A connection attempt (by dogd, trying
 to connect because it thinks there is a Bitcoin node on that address:port) to
 such service may be considered a malicious action by an ultra-paranoid
 administrator. An example for such a port is 22 (ssh). On the other hand,
@@ -16,7 +16,7 @@ connection attempts to public services that usually do not require
 authentication are unlikely to be considered a malicious action, e.g. port 80
 (http).
 
-Below is a list of "bad" ports which Dogecash avoids when choosing a peer to
+Below is a list of "bad" ports which dogd avoids when choosing a peer to
 connect to. If a node is listening on such a port, it will likely receive less
 incoming connections.
 

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -1,6 +1,6 @@
-# PSBT Howto for Dogecash
+# PSBT Howto for dogd
 
-Since Dogecash v0.20.7, an RPC interface exists for Partially Signed Bitcoin
+Since dogd v0.20.7, an RPC interface exists for Partially Signed Bitcoin
 Transactions (PSBTs, as specified in
 [BIP 174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)).
 
@@ -46,7 +46,7 @@ The names above in bold are the names of the roles defined in BIP174. They're
 useful in understanding the underlying steps, but in practice, software and
 hardware implementations will typically implement multiple roles simultaneously.
 
-## PSBT in Dogecash
+## PSBT in dogd
 
 ### RPCs
 
@@ -90,10 +90,10 @@ hardware implementations will typically implement multiple roles simultaneously.
 
 ### Workflows
 
-#### Multisig with multiple Dogecash instances
+#### Multisig with multiple dogd instances
 
 Alice, Bob, and Carol want to create a 2-of-3 multisig address. They're all using
-Dogecash. We assume their wallets only contain the multisig funds. In case
+dogd. We assume their wallets only contain the multisig funds. In case
 they also have a personal wallet, this can be accomplished through the
 multiwallet feature - possibly resulting in a need to add `-rpcwallet=name` to
 the command line in case `dogecoin-cli` is used.

--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -12,7 +12,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 ## Memory pool
 
-- In Dogecash there is a memory pool limiter which can be configured with `-maxmempool=<n>`, where `<n>` is the size in MB (1000). The default value is `300`.
+- In dogd there is a memory pool limiter which can be configured with `-maxmempool=<n>`, where `<n>` is the size in MB (1000). The default value is `300`.
   - The minimum value for `-maxmempool` is 5.
   - A lower maximum mempool size means that transactions will be evicted sooner. This will affect any uses of `dogecoind` that process unconfirmed transactions.
 
@@ -47,4 +47,4 @@ export MALLOC_ARENA_MAX=1
 dogecoind
 ```
 
-The behavior was introduced to increase CPU locality of allocated memory and performance with concurrent allocation, so this setting could in theory reduce performance. However, in Dogecash very little parallel allocation happens, so the impact is expected to be small or absent.
+The behavior was introduced to increase CPU locality of allocated memory and performance with concurrent allocation, so this setting could in theory reduce performance. However, in dogd very little parallel allocation happens, so the impact is expected to be small or absent.

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -3,7 +3,7 @@ Reduce Traffic
 
 Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
-By default, Dogecash allows up to 4096 connections to different peers, 10 of
+By default, dogd allows up to 4096 connections to different peers, 10 of
 which are outbound. You can therefore, have at most 4086 inbound connections.
 Of the 10 outbound peers, there can be 8 full-relay connections and 2
 block-relay-only ones.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,6 +1,6 @@
-# Dogecash 0.30.5 Release Notes
+# dogd 0.30.5 Release Notes
 
-Dogecash version 0.30.5 is now available from:
+dogd version 0.30.5 is now available from:
 
   <https://download.bitcoinabc.org/0.30.5/>
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -1,4 +1,4 @@
-Dogecash Release Process
+dogd Release Process
 ===========================
 
 

--- a/doc/test-shell.md
+++ b/doc/test-shell.md
@@ -22,9 +22,9 @@ user inputs. Such environments include the Python3 command line interpreter or
 * Python3
 * `dogecoind` built in the same repository as the `TestShell`.
 
-## 2. Importing `TestShell` from the Dogecash repository
+## 2. Importing `TestShell` from the dogd repository
 
-We can import the `TestShell` by adding the path of the Dogecash
+We can import the `TestShell` by adding the path of the dogd
 `test_framework` module to the beginning of the PATH variable, and then
 importing the `TestShell` class from the `test_shell` sub-package.
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,13 +1,13 @@
 # TOR SUPPORT IN BITCOIN
 
-It is possible to run Dogecash as a Tor onion service, and connect to such services.
+It is possible to run dogd as a Tor onion service, and connect to such services.
 
 The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on port 9150. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
 configure Tor.
 
-## How to see information about your Tor configuration via Dogecash
+## How to see information about your Tor configuration via dogd
 
-There are several ways to see your local onion address in Dogecash:
+There are several ways to see your local onion address in dogd:
 - in the debug log (grep for "tor:" or "AddLocal")
 - in the output of RPC `getnetworkinfo` in the "localaddresses" section
 - in the output of the CLI `-netinfo` peer connections dashboard
@@ -16,9 +16,9 @@ You may set the `-debug=tor` config logging option to have additional
 information in the debug log about your Tor configuration.
 
 
-## 1. Run Dogecash behind a Tor proxy
+## 1. Run dogd behind a Tor proxy
 
-The first step is running Dogecash behind a Tor proxy. This will already anonymize all
+The first step is running dogd behind a Tor proxy. This will already anonymize all
 outgoing connections, but more is possible.
 
 	-proxy=ip:port  Set the proxy server. If SOCKS5 is selected (default), this proxy
@@ -55,15 +55,15 @@ In a typical situation, this suffices to run behind a Tor proxy:
 
 	./dogecoind -proxy=127.0.0.1:9050
 
-## 2. Automatically create a Dogecash onion service
+## 2. Automatically create a dogd onion service
 
-Dogecash makes use of Tor's control socket API to create and destroy
+dogd makes use of Tor's control socket API to create and destroy
 ephemeral onion services programmatically. This means that if Tor is running and
-proper authentication has been configured, Dogecash automatically creates an
+proper authentication has been configured, dogd automatically creates an
 onion service to listen on. The goal is to increase the number of available
 onion nodes.
 
-This feature is enabled by default if Dogecash is listening (`-listen`) and
+This feature is enabled by default if dogd is listening (`-listen`) and
 it requires a Tor connection to work. It can be explicitly disabled with
 `-listenonion=0`. If it is not disabled, it can be configured using the
 `-torcontrol` and `-torpassword` settings.
@@ -147,7 +147,7 @@ Manual](https://2019.www.torproject.org/docs/tor-manual.html.en) for more
 details).
 
 
-## 3. Manually create a Dogecash onion service
+## 3. Manually create a dogd onion service
 
 You can also manually configure your node to be reachable from the Tor network.
 Add these lines to your `/etc/tor/torrc` (or equivalent config file):
@@ -206,7 +206,7 @@ for normal IPv4/IPv6 communication, use:
 
 ## 4. Privacy recommendations
 
-- Do not add anything but Dogecash ports to the onion service created in section 3.
+- Do not add anything but dogd ports to the onion service created in section 3.
   If you run a web service too, create a new onion service for that.
   Otherwise it is trivial to link them, which may reduce privacy. Onion
   services created automatically (as in section 2) always have only one port

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -1,6 +1,6 @@
-# User-space, Statically Defined Tracing (USDT) for Dogecash
+# User-space, Statically Defined Tracing (USDT) for dogd
 
-Dogecash includes statically defined tracepoints to allow for more
+dogd includes statically defined tracepoints to allow for more
 observability during development, debugging, code review, and production usage.
 These tracepoints make it possible to keep track of custom statistics and
 enable detailed monitoring of otherwise hidden internals. They have
@@ -112,7 +112,7 @@ Arguments passed:
 
 The following tracepoints cover the in-memory UTXO cache. UTXOs are, for example,
 added to and removed (spent) from the cache when we connect a new block.
-**Note**: Dogecash uses temporary clones of the _main_ UTXO cache
+**Note**: dogd uses temporary clones of the _main_ UTXO cache
 (`chainstate.CoinsTip()`). For example, the RPCs `generateblock` and
 `getblocktemplate` call `TestBlockValidity()`, which applies the UTXO set
 changes to a temporary cache. Similarly, mempool consistency checks, which are
@@ -168,7 +168,7 @@ Arguments passed:
 4. Value of the coin as `pointer to unsigned chars` (e.g. "123456.78 XEC")
 5. If the coin is a coinbase as `bool`
 
-## Adding tracepoints to Dogecash
+## Adding tracepoints to dogd
 
 To add a new tracepoint, `#include <util/trace.h>` in the compilation unit where
 the tracepoint is inserted. Use one of the `TRACEx` macros listed below
@@ -268,7 +268,7 @@ USDT support.
 
 ### GDB - GNU Project Debugger
 
-To list probes in Dogecash, use `info probes` in `gdb`:
+To list probes in dogd, use `info probes` in `gdb`:
 
 ```
 $ gdb ./src/dogecoind
@@ -283,7 +283,7 @@ stap validation block_connected  0x00000000002fb10c /src/dogecoind
 
 ### With `readelf`
 
-The `readelf` tool can be used to display the USDT tracepoints in Dogecash.
+The `readelf` tool can be used to display the USDT tracepoints in dogd.
 Look for the notes with the description `NT_STAPSDT`.
 
 ```

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -5,7 +5,7 @@ connections, inter-process communication, and shared-memory,
 providing various message-oriented semantics such as publish/subscribe,
 request/reply, and push/pull.
 
-The Dogecash daemon can be configured to act as a trusted "border
+The dogd daemon can be configured to act as a trusted "border
 router", implementing the bitcoin wire protocol and relay, making
 consensus decisions, maintaining the local blockchain database,
 broadcasting locally generated transactions into the network, and
@@ -33,7 +33,7 @@ buffering or reassembly.
 
 ## Prerequisites
 
-The ZeroMQ feature in Dogecash requires the ZeroMQ API >= 4.1.5
+The ZeroMQ feature in dogd requires the ZeroMQ API >= 4.1.5
 [libzmq](https://github.com/zeromq/libzmq/releases).
 For version information, see [dependencies.md](dependencies.md).
 Typically, it is packaged by distributions as something like

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,7 +28,7 @@ option(ENABLE_UPNP "Enable UPnP support" ON)
 option(START_WITH_UPNP "Make UPnP the default to map ports" OFF)
 option(ENABLE_NATPMP "Enable NAT-PMP support" ON)
 option(START_WITH_NATPMP "Make NAT-PMP the default to map ports" OFF)
-option(ENABLE_CLANG_TIDY "Enable clang-tidy checks for Dogecash" OFF)
+option(ENABLE_CLANG_TIDY "Enable clang-tidy checks for dogd" OFF)
 option(ENABLE_PROFILING "Select the profiling tool to use" OFF)
 option(ENABLE_TRACING "Enable eBPF user static defined tracepoints" OFF)
 
@@ -954,7 +954,7 @@ if(BUILD_BITCOIN_CHAINSTATE)
 		versionbits.cpp
 		warnings.cpp
 
-		# Dogecash specific dependencies that will not go away with Core backports
+		# dogd specific dependencies that will not go away with Core backports
 		addrdb.cpp   # via banman.cpp
 		addrman.cpp  # via net.cpp
 		banman.cpp   # via net.cpp

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -146,12 +146,12 @@ template <typename Stream> void AddrManImpl::Serialize(Stream &s_) const {
      * * format version byte (@see `Format`)
      * * lowest compatible format version byte. This is used to help old
      * software decide whether to parse the file. For example:
-     *   * Dogecash version N knows how to parse up to format=3. If a new
+     *   * dogd version N knows how to parse up to format=3. If a new
      * format=4 is introduced in version N+1 that is compatible with format=3
      * and it is known that version N will be able to parse it, then version N+1
      * will write (format=4, lowest_compatible=3) in the first two bytes of the
      * file, and so version N will still try to parse it.
-     *   * Dogecash version N+2 introduces a new incompatible format=5. It
+     *   * dogd version N+2 introduces a new incompatible format=5. It
      * will write (format=5, lowest_compatible=5) and so any versions that do
      * not know how to parse format=5 will not try to read the file.
      * * nKey

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -16,7 +16,7 @@
  * for both dogecoind and dogecoin-qt, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-const std::string CLIENT_NAME("Dogecash");
+const std::string CLIENT_NAME("dogd");
 
 #ifdef HAVE_BUILD_INFO
 #include <obj/build.h>

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -757,12 +757,12 @@ std::string HelpMessageOpt(const std::string &option,
 }
 
 fs::path GetDefaultDataDir() {
-    // Windows: C:\Users\Username\AppData\Roaming\Dogecash
-    // macOS: ~/Library/Application Support/Dogecash
-    // Unix-like: ~/.dogecash
+    // Windows: C:\Users\Username\AppData\Roaming\dogd
+    // macOS: ~/Library/Application Support/dogd
+    // Unix-like: ~/.dogd
 #ifdef WIN32
     // Windows
-    return GetSpecialFolderPath(CSIDL_APPDATA) / "Dogecash";
+    return GetSpecialFolderPath(CSIDL_APPDATA) / "dogd";
 #else
     fs::path pathRet;
     char *pszHome = getenv("HOME");
@@ -773,10 +773,10 @@ fs::path GetDefaultDataDir() {
     }
 #ifdef MAC_OSX
     // macOS
-    return pathRet / "Library/Application Support/Dogecash";
+    return pathRet / "Library/Application Support/dogd";
 #else
     // Unix-like
-    return pathRet / ".dogecash";
+    return pathRet / ".dogd";
 #endif
 #endif
 }

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -262,7 +262,7 @@
        <item>
         <widget class="QCheckBox" name="mapPortNatpmp">
          <property name="toolTip">
-          <string>Automatically open the Dogecash client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</string>
+          <string>Automatically open the dogd client port on the router. This only works when your router supports NAT-PMP and it is enabled. The external port could be random.</string>
          </property>
          <property name="text">
           <string>Map port using NA&amp;T-PMP</string>

--- a/src/qt/locale/bitcoin_af.ts
+++ b/src/qt/locale/bitcoin_af.ts
@@ -908,8 +908,8 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Information</source>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -1932,7 +1932,7 @@
         <translation>حدد مجلد المعلومات</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>جوهر البيت كوين</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -1258,8 +1258,8 @@
         <translation>Запусціць у фоне як дэман і прымаць каманды</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Do you want to rebuild the block database now?</source>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -2346,7 +2346,7 @@
         <translation>Въведете Ваш публичен адрес</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Биткойн ядро</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_bg_BG.ts
+++ b/src/qt/locale/bitcoin_bg_BG.ts
@@ -420,7 +420,7 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Биткойн ядро</translation>
     </message>
     </context>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -2842,8 +2842,8 @@
         <translation>No s'ha pogut iniciar el servidor HTTP. Vegeu debug.log per a més detalls.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_ca@valencia.ts
+++ b/src/qt/locale/bitcoin_ca@valencia.ts
@@ -2558,8 +2558,8 @@
         <translation>Executa en segon pla com a programa dimoni i accepta ordes</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -2842,8 +2842,8 @@
         <translation>No s'ha pogut iniciar el servidor HTTP. Vegeu debug.log per a més detalls.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -3070,8 +3070,8 @@
         <translation>Nemohu spustit HTTP server. Detaily viz v debug.log.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -484,7 +484,7 @@
         <translation>Opsiynau:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -3070,8 +3070,8 @@
         <translation>Kunne ikke starte HTTP-server. Se fejlretningslog for detaljer.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -3066,8 +3066,8 @@
         <translation>Kann HTTP Server nicht starten. Siehe debug log für Details.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -1443,8 +1443,8 @@
         <translation>Εκτέλεση στο παρασκήνιο κι αποδοχή εντολών</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_en_GB.ts
+++ b/src/qt/locale/bitcoin_en_GB.ts
@@ -1906,8 +1906,8 @@
         <translation>Unable to start HTTP server. See debug log for details.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -1338,7 +1338,7 @@
         <translation>Ruli fone kiel demono kaj akcepti komandojn</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitmono</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -3073,8 +3073,8 @@
         <translation>No se ha podido comenzar el servidor HTTP. Ver debug log para detalles.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -772,7 +772,7 @@
 </translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>bitcoin abc</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -296,8 +296,8 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Insufficient funds</source>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -1123,7 +1123,7 @@
 </translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_ES.ts
+++ b/src/qt/locale/bitcoin_es_ES.ts
@@ -2925,8 +2925,8 @@
         <translation>No se ha podido comenzar el servidor HTTP. Ver debug log para detalles.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -604,7 +604,7 @@
         <translation>Opciones:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_es_VE.ts
+++ b/src/qt/locale/bitcoin_es_VE.ts
@@ -608,8 +608,8 @@
         <translation>Correr en segundo plano como daemon y aceptar comandos</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -1758,7 +1758,7 @@
         <translation>Tööta taustal ning aktsepteeri käsklusi</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Bitcoini ABC</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_et_EE.ts
+++ b/src/qt/locale/bitcoin_et_EE.ts
@@ -760,8 +760,8 @@
         <translation>Valikud:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Information</source>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -1598,7 +1598,7 @@
         <translation>اجرا در پشت زمینه به‌صورت یک سرویس و پذیرش دستورات</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation> ABC Bitcoin </translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -1790,7 +1790,7 @@
         <translation>HTTP-palvelinta ei voitu käynnistää. Katso debug-lokista lisätietoja.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Bitcoin-abc</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -3070,8 +3070,8 @@
         <translation>Impossible de démarrer le serveur HTTP. Voir le journal de débogage pour plus de détails.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_fr_FR.ts
+++ b/src/qt/locale/bitcoin_fr_FR.ts
@@ -1662,8 +1662,8 @@
         <translation>Impossible de démarrer le serveur HTTP. Voir le journal de débogage pour plus de détails.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>&lt;category&gt; can be:</source>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -1028,7 +1028,7 @@
         <translation>Executar no fondo como un demo e aceptar comandos</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Core de Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -1660,7 +1660,7 @@
         <translation>ריצה כסוכן ברקע וקבלת פקודות</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ליבת ביטקוין</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -1378,8 +1378,8 @@
 </translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -1400,8 +1400,8 @@
         <translation>Berjalan dibelakang sebagai daemin dan menerima perintah</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -2595,8 +2595,8 @@ Per specificare più URL separarli con una barra verticale "|".</translation>
         <translation>Impossibile avviare il server HTTP. Dettagli nel log di debug.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -3070,7 +3070,7 @@
         <translation>HTTPサーバを開始できませんでした。詳細はデバッグログをご確認ください。</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Bitcoin のコア</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -1172,8 +1172,8 @@
         <translation>რეზიდენტულად გაშვება და კომანდების მიღება</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -2310,7 +2310,7 @@
         <translation>HTTP 서버를 시작할 수 없습니다. 자세한 사항은 디버그 로그를 확인 하세요.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>비트코인 코어</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -768,8 +768,8 @@
         <translation>Operare infere sicut daemon et mandata accipe</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -936,8 +936,8 @@
         <translation>Dirbti fone kaip šešėlyje ir priimti komandas</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Error opening block database</source>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -1124,8 +1124,8 @@
         <translation>Darbināt fonā kā servisu un pieņemt komandas</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>&lt;category&gt; can be:</source>

--- a/src/qt/locale/bitcoin_mk_MK.ts
+++ b/src/qt/locale/bitcoin_mk_MK.ts
@@ -578,7 +578,7 @@
         <translation>Опции:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Биткоин ABC</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -1862,8 +1862,8 @@
         <translation>Kunne ikke starte HTTP server. Se debug logg for detaljer.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -2870,8 +2870,8 @@
         <translation>Niet mogelijk ok HTTP-server te starten. Zie debuglogboek voor details.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -752,7 +752,7 @@
         <translation>Gumana king gulut bilang daemon at tumanggap commands</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -2499,7 +2499,7 @@ Zwróć uwagę, że poprawnie zweryfikowana wiadomość potwierdza to, że nadaw
         <translation>Uruchomienie serwera HTTP nie powiodło się. Zobacz dziennik debugowania, aby uzyskać więcej szczegółów.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoina</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -3066,8 +3066,8 @@
         <translation>Não foi possível iniciar o servidor HTTP. Veja o log para detaihes.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -2195,8 +2195,8 @@
         <translation>Não é possível iniciar o servidor HTTP. Verifique o debug.log para detalhes.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)</source>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -748,8 +748,8 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Information</source>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -1606,7 +1606,7 @@
         <translation>Rulează în fundal ca un demon şi acceptă comenzi</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -3058,8 +3058,8 @@
         <translation>Невозможно запустить HTTP сервер. Смотри debug лог для подробностей.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_ru_RU.ts
+++ b/src/qt/locale/bitcoin_ru_RU.ts
@@ -59,7 +59,7 @@
     <name>BitcoinGUI</name>
     <message>
         <source>Bitcoin</source>
-        <translation>Dogecash</translation>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>&amp;Command-line options</source>
@@ -228,8 +228,8 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway</source>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -2831,8 +2831,8 @@
         <translation>Nepodarilo sa spustiť HTTP server. Pre viac detailov zobrazte debug log.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -1590,8 +1590,8 @@
         <translation>Teci v ozadju in sprejemaj ukaze</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_sq.ts
+++ b/src/qt/locale/bitcoin_sq.ts
@@ -784,7 +784,7 @@
         <translation>Opsionet:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>ABC Bitcoin</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_sr@latin.ts
+++ b/src/qt/locale/bitcoin_sr@latin.ts
@@ -406,8 +406,8 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Information</source>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -2239,8 +2239,8 @@ Var vänlig och försök igen.</translation>
         <translation>Kunde inte starta HTTP-server. Se avlusningsloggen för detaljer.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -708,7 +708,7 @@
 <context>
     <name>bitcoin-abc</name>
     <message>
-        <source>Dogecash</source>
+        <source>dogd</source>
         <translation>Bitcoin மையம்</translation>
     </message>
     <message>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -3066,8 +3066,8 @@
         <translation>HTTP sunucusu başlatılamadı. Ayrıntılar için debug.log dosyasına bakınız.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -1710,8 +1710,8 @@
         <translation>Неможливо запустити HTTP-сервер. Детальніший опис наведено в журналі зневадження.</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -1208,8 +1208,8 @@
         <translation>Демон сифатида орқа фонда ишга туширинг ва буйруқларга рози бўлинг</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>Connection options:</source>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -998,8 +998,8 @@
         <translation>Lựa chọn:</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>(default: %u)</source>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -3024,8 +3024,8 @@
         <translation>无法启动HTTP服务，查看日志获取更多信息</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -3067,8 +3067,8 @@
         <translation>無法啟動 HTTP 伺服器。詳情請看除錯紀錄。</translation>
     </message>
     <message>
-        <source>Dogecash</source>
-        <translation>Dogecash</translation>
+        <source>dogd</source>
+        <translation>dogd</translation>
     </message>
     <message>
         <source>The %s developers</source>

--- a/src/seeder/test/message_writer_tests.cpp
+++ b/src/seeder/test/message_writer_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(simple_header_and_payload_message_writer_test) {
     CService service;
     CAddress addrTo(service, ServiceFlags(NODE_NETWORK));
     CAddress addrFrom(service, ServiceFlags(NODE_NETWORK));
-    std::string user_agent = "/Dogecash:0.0.0(seeder)/";
+    std::string user_agent = "/dogd:0.0.0(seeder)/";
     int start_height = 1;
 
     CDataStream versionPayload(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/seeder/test/p2p_messaging_tests.cpp
+++ b/src/seeder/test/p2p_messaging_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(process_version_msg) {
     uint64_t addr_to_services = vAddr[0].nServices;
     CService addr_from;
     uint64_t nonce = 0;
-    std::string user_agent = "/Dogecash:0.0.0(seeder)/";
+    std::string user_agent = "/dogd:0.0.0(seeder)/";
 
     // Don't include the time in CAddress serialization. See D14753.
     versionMessage << INIT_PROTO_VERSION << serviceflags << GetTime()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -311,7 +311,7 @@ function(add_boost_test_runners_with_upgrade_activated SUITE EXECUTABLE)
 			"--catch_system_errors=no"
 			--
 			"-printtoconsole=1"
-			"-testsuitename=Dogecash unit tests with next upgrade activated"
+			"-testsuitename=dogd unit tests with next upgrade activated"
 			# May. 16th, 2024 at 08:00:00
 			-augustoactivationtime=1715846400
 		)

--- a/src/test/fixture.cpp
+++ b/src/test/fixture.cpp
@@ -6,7 +6,7 @@
  * See
  * https://www.boost.org/doc/libs/1_78_0/libs/test/doc/html/boost_test/adv_scenarios/single_header_customizations/multiple_translation_units.html
  */
-#define BOOST_TEST_MODULE Dogecash unit tests
+#define BOOST_TEST_MODULE dogd unit tests
 
 #include <common/system.h>
 

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -304,54 +304,54 @@ BOOST_AUTO_TEST_CASE(patharg) {
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), win_root_path);
 #endif
 
-    const fs::path absolute_path{"/home/user/.dogecash"};
-    ResetArgs(local_args, "-dir=/home/user/.dogecash");
+    const fs::path absolute_path{"/home/user/.dogd"};
+    ResetArgs(local_args, "-dir=/home/user/.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/root/../home/user/.dogecash");
+    ResetArgs(local_args, "-dir=/root/../home/user/.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/./user/.dogecash");
+    ResetArgs(local_args, "-dir=/home/./user/.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/user/.dogecash/");
+    ResetArgs(local_args, "-dir=/home/user/.dogd/");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/user/.dogecash//");
+    ResetArgs(local_args, "-dir=/home/user/.dogd//");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/user/.dogecash/.");
+    ResetArgs(local_args, "-dir=/home/user/.dogd/.");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/user/.dogecash/./");
+    ResetArgs(local_args, "-dir=/home/user/.dogd/./");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    ResetArgs(local_args, "-dir=/home/user/.dogecash/.//");
+    ResetArgs(local_args, "-dir=/home/user/.dogd/.//");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), absolute_path);
 
-    const fs::path relative_path{"user/.dogecash"};
-    ResetArgs(local_args, "-dir=user/.dogecash");
+    const fs::path relative_path{"user/.dogd"};
+    ResetArgs(local_args, "-dir=user/.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=somewhere/../user/.dogecash");
+    ResetArgs(local_args, "-dir=somewhere/../user/.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/./.dogecash");
+    ResetArgs(local_args, "-dir=user/./.dogd");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/.dogecash/");
+    ResetArgs(local_args, "-dir=user/.dogd/");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/.dogecash//");
+    ResetArgs(local_args, "-dir=user/.dogd//");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/.dogecash/.");
+    ResetArgs(local_args, "-dir=user/.dogd/.");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/.dogecash/./");
+    ResetArgs(local_args, "-dir=user/.dogd/./");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
-    ResetArgs(local_args, "-dir=user/.dogecash/.//");
+    ResetArgs(local_args, "-dir=user/.dogd/.//");
     BOOST_CHECK_EQUAL(local_args.GetPathArg("-dir"), relative_path);
 
     // Check negated and default argument handling. Specifying an empty argument

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(test_userAgent) {
     gArgs.ForceSetMultiArg("-uacomment", {uacomment});
 
     const std::string versionMessage =
-        "/Dogecash:" + ToString(CLIENT_VERSION_MAJOR) + "." +
+        "/dogd:" + ToString(CLIENT_VERSION_MAJOR) + "." +
         ToString(CLIENT_VERSION_MINOR) + "." +
         ToString(CLIENT_VERSION_REVISION) + "(EB8.0; " + uacomment + ")/";
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,7 @@ function(add_functional_test_check TARGET DESCRIPTION)
 		TEST_COMMAND
 			"${Python_EXECUTABLE}"
 			./functional/test_runner.py
-			"--testsuitename=Dogecash ${DESCRIPTION}"
+			"--testsuitename=dogd ${DESCRIPTION}"
 			${JUNIT_OUTPUT}
 			${EXTENDED_TIMEOUT}
 			${ARGN}

--- a/test/functional/abc-cmdline.py
+++ b/test/functional/abc-cmdline.py
@@ -91,7 +91,7 @@ class ABC_CmdLine_Test(BitcoinTestFramework):
         self.start_node(0, [f"-excessiveblocksize={2 * LEGACY_MAX_BLOCK_SIZE}"])
         self.check_excessive(2 * LEGACY_MAX_BLOCK_SIZE)
         # Check for EB correctness in the subver string
-        self.check_subversion(r"/Dogecash:.*\(EB2\.0; .*\)/")
+        self.check_subversion(r"/dogd:.*\(EB2\.0; .*\)/")
 
         self.log.info(
             "  Attempt to set below legacy limit of 1MB - try "

--- a/test/functional/abc_rpc_excessiveblock.py
+++ b/test/functional/abc_rpc_excessiveblock.py
@@ -58,7 +58,7 @@ class ExcessiveBlockSizeRPCTest(BitcoinTestFramework):
         ebs = getsize["excessiveBlockSize"]
         assert_equal(ebs, 2 * ONE_MEGABYTE)
         # Check for EB correctness in the subver string
-        self.check_subversion(r"/Dogecash:.*\(EB2\.0; .*\)/")
+        self.check_subversion(r"/dogd:.*\(EB2\.0; .*\)/")
 
         # Check setting to 13MB
         setexcessiveblock(13 * ONE_MEGABYTE)
@@ -66,7 +66,7 @@ class ExcessiveBlockSizeRPCTest(BitcoinTestFramework):
         ebs = getsize["excessiveBlockSize"]
         assert_equal(ebs, 13 * ONE_MEGABYTE)
         # Check for EB correctness in the subver string
-        self.check_subversion(r"/Dogecash:.*\(EB13\.0; .*\)/")
+        self.check_subversion(r"/dogd:.*\(EB13\.0; .*\)/")
 
         # Check setting to 13.14MB
         setexcessiveblock(13140000)
@@ -74,7 +74,7 @@ class ExcessiveBlockSizeRPCTest(BitcoinTestFramework):
         ebs = getsize["excessiveBlockSize"]
         assert_equal(ebs, 13.14 * ONE_MEGABYTE)
         # check for EB correctness in the subver string
-        self.check_subversion(r"/Dogecash:.*\(EB13\.1; .*\)/")
+        self.check_subversion(r"/dogd:.*\(EB13\.1; .*\)/")
 
     def run_test(self):
         self.test_excessiveblock()

--- a/test/functional/feature_uaclient.py
+++ b/test/functional/feature_uaclient.py
@@ -18,7 +18,7 @@ class UseragentTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("test -uaclientname and -uaclientversion")
         default_useragent = self.nodes[0].getnetworkinfo()["subversion"]
-        expected = "/Dogecash:"
+        expected = "/dogd:"
         assert_equal(default_useragent[: len(expected)], expected)
         default_version = default_useragent[default_useragent.index(":") + 1 :]
         default_version = default_version[: default_version.index("/")]
@@ -30,13 +30,13 @@ class UseragentTest(BitcoinTestFramework):
 
         self.restart_node(0, ["-uaclientversion=123.45"])
         foo_ua = self.nodes[0].getnetworkinfo()["subversion"]
-        expected = "/Dogecash:123.45"
+        expected = "/dogd:123.45"
         assert_equal(foo_ua[: len(expected)], expected)
 
         self.log.info("non-numeric version allowed (although not recommended in BIP14)")
         self.restart_node(0, ["-uaclientversion=Version Two"])
         foo_ua = self.nodes[0].getnetworkinfo()["subversion"]
-        expected = "/Dogecash:Version Two"
+        expected = "/dogd:Version Two"
         assert_equal(foo_ua[: len(expected)], expected)
 
         self.log.info("test -uaclient doesn't break -uacomment")

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -167,7 +167,7 @@ class WalletDumpTest(BitcoinTestFramework):
         ) = read_dump(wallet_unenc_dump, addrs, [multisig_addr], None)
         # Check that file is not corrupt
         assert "# End of dump" in found_comments
-        assert found_comments[0].startswith("# Wallet dump created by Dogecash")
+        assert found_comments[0].startswith("# Wallet dump created by dogd")
         assert_equal(
             dump_time_str,
             next(c for c in found_comments if c.startswith("# * Created on")),

--- a/web/explorer/explorer-server/templates/base.html
+++ b/web/explorer/explorer-server/templates/base.html
@@ -93,7 +93,7 @@
             <script>
                 document.write(new Date().getFullYear());
             </script>
-            Dogecash
+            dogd
         </div>
     </body>
     <script>


### PR DESCRIPTION
DogeCash is already a name that has been taken, and dogd is unused.