### PR TITLE
[doged] Fix `sendtoaddress`

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2019,8 +2019,8 @@ bool CWallet::SignTransaction(CMutableTransaction &tx) const {
     std::map<int, std::string> input_errors;
     return SignTransaction(tx, coins,
                            GetSignScriptFlags() & SCRIPT_ENABLE_SIGHASH_FORKID
-                               ? SigHashType()
-                               : SigHashType().withForkId(),
+                               ? SigHashType().withForkId()
+                               : SigHashType(),
                            input_errors);
 }
 


### PR DESCRIPTION
There was an oversight in `CWallet::SignTransaction`, which is fixed in this PR.