### PR TITLE
[doged] Turn on legacyscriptrules per default on regtest

### DIFF
--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -420,8 +420,8 @@ public:
         consensus.digishieldHeight = 1450;
         // keep maturity same as Bitcoin for tests
         consensus.initialCoinbaseMaturity = REGTEST_COINBASE_MATURITY;
-        // legacy rules disabled for regtest so we don't refactor the universe
-        consensus.enforceLegacyScriptRules = false;
+        // legacy rules enabled for regtest
+        consensus.enforceLegacyScriptRules = true;
 
         diskMagic[0] = 0x94;
         diskMagic[1] = 0xb1;

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -481,6 +481,7 @@ def write_config(config_path, *, n, chain, extra_config="", disable_autoconnect=
         f.write("natpmp=0\n")
         f.write("usecashaddr=1\n")
         f.write("usedogeunit=0\n")
+        f.write("legacyscriptrules=0\n")
         f.write("minrelaytxfee=10\n")
         f.write("blockmintxfee=10\n")
         # Increase peertimeout to avoid disconnects while using mocktime.


### PR DESCRIPTION
We want to have a uniform behavior across the different chains, else testing becomes really difficult.