### PR TITLE
Adjust avalanche parameters for use on dogecoin mainnet

### DIFF
--- a/src/avalanche/avalanche.h
+++ b/src/avalanche/avalanche.h
@@ -44,7 +44,7 @@ static constexpr size_t AVALANCHE_DEFAULT_COOLDOWN = 100;
  * quorum.
  */
 static constexpr Amount AVALANCHE_DEFAULT_MIN_QUORUM_STAKE =
-    int64_t(1'000'000'000'000) * SATOSHI; // 10B XEC
+    int64_t(100'000'000'000'000) * SATOSHI; // 1M DOGE
 
 /**
  * Default minimum percentage of stake-weighted peers we must have a node for to

--- a/src/avalanche/proof.h
+++ b/src/avalanche/proof.h
@@ -33,12 +33,12 @@ static constexpr int AVALANCHE_MAX_PROOF_STAKES = 1000;
  * Minimum number of confirmations before a stake utxo is mature enough to be
  * included into a proof.
  */
-static constexpr int AVALANCHE_DEFAULT_STAKE_UTXO_CONFIRMATIONS = 2016;
+static constexpr int AVALANCHE_DEFAULT_STAKE_UTXO_CONFIRMATIONS = 20160;
 
 namespace avalanche {
 
 /** Minimum amount per utxo */
-static constexpr Amount PROOF_DUST_THRESHOLD = 100 * COIN;
+static constexpr Amount PROOF_DUST_THRESHOLD = 10000 * COIN;
 
 class ProofValidationState;
 

--- a/src/avalanche/test/peermanager_tests.cpp
+++ b/src/avalanche/test/peermanager_tests.cpp
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(remove_peer) {
         BOOST_CHECK(pm.addNode(InsecureRand32(), p->getId()));
     }
 
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 40000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 4000000);
     BOOST_CHECK_EQUAL(pm.getFragmentation(), 0);
 
     for (int i = 0; i < 100; i++) {
@@ -413,13 +413,13 @@ BOOST_AUTO_TEST_CASE(remove_peer) {
 
     // Remove one peer, it nevers show up now.
     BOOST_CHECK(pm.removePeer(peerids[2]));
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 40000);
-    BOOST_CHECK_EQUAL(pm.getFragmentation(), 10000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 4000000);
+    BOOST_CHECK_EQUAL(pm.getFragmentation(), 1000000);
 
     // Make sure we compact to never get NO_PEER.
-    BOOST_CHECK_EQUAL(pm.compact(), 10000);
+    BOOST_CHECK_EQUAL(pm.compact(), 1000000);
     BOOST_CHECK(pm.verify());
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 30000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 3000000);
     BOOST_CHECK_EQUAL(pm.getFragmentation(), 0);
 
     for (int i = 0; i < 100; i++) {
@@ -434,22 +434,22 @@ BOOST_AUTO_TEST_CASE(remove_peer) {
         BOOST_CHECK(pm.addNode(InsecureRand32(), p->getId()));
     }
 
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 70000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 7000000);
     BOOST_CHECK_EQUAL(pm.getFragmentation(), 0);
 
     BOOST_CHECK(pm.removePeer(peerids[0]));
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 70000);
-    BOOST_CHECK_EQUAL(pm.getFragmentation(), 10000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 7000000);
+    BOOST_CHECK_EQUAL(pm.getFragmentation(), 1000000);
 
     // Removing the last entry do not increase fragmentation.
     BOOST_CHECK(pm.removePeer(peerids[7]));
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 60000);
-    BOOST_CHECK_EQUAL(pm.getFragmentation(), 10000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 6000000);
+    BOOST_CHECK_EQUAL(pm.getFragmentation(), 1000000);
 
     // Make sure we compact to never get NO_PEER.
-    BOOST_CHECK_EQUAL(pm.compact(), 10000);
+    BOOST_CHECK_EQUAL(pm.compact(), 1000000);
     BOOST_CHECK(pm.verify());
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 50000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 5000000);
     BOOST_CHECK_EQUAL(pm.getFragmentation(), 0);
 
     for (int i = 0; i < 100; i++) {
@@ -483,14 +483,14 @@ BOOST_AUTO_TEST_CASE(compact_slots) {
         pm.removePeer(p);
     }
 
-    BOOST_CHECK_EQUAL(pm.getSlotCount(), 30000);
-    BOOST_CHECK_EQUAL(pm.getFragmentation(), 30000);
+    BOOST_CHECK_EQUAL(pm.getSlotCount(), 3000000);
+    BOOST_CHECK_EQUAL(pm.getFragmentation(), 3000000);
 
     for (int i = 0; i < 100; i++) {
         BOOST_CHECK_EQUAL(pm.selectPeer(), NO_PEER);
     }
 
-    BOOST_CHECK_EQUAL(pm.compact(), 30000);
+    BOOST_CHECK_EQUAL(pm.compact(), 3000000);
     BOOST_CHECK(pm.verify());
     BOOST_CHECK_EQUAL(pm.getSlotCount(), 0);
     BOOST_CHECK_EQUAL(pm.getFragmentation(), 0);
@@ -504,7 +504,7 @@ BOOST_AUTO_TEST_CASE(node_crud) {
 
     // Create one peer.
     auto proof =
-        buildRandomProof(active_chainstate, 10000000 * MIN_VALID_PROOF_SCORE);
+        buildRandomProof(active_chainstate, 100000 * MIN_VALID_PROOF_SCORE);
     BOOST_CHECK(pm.registerProof(proof));
     BOOST_CHECK_EQUAL(pm.selectNode(), NO_NODE);
 
@@ -1749,7 +1749,7 @@ BOOST_AUTO_TEST_CASE(connected_score_tracking) {
 
     // Create one peer without a node. Its score should be registered but not
     // connected
-    Score score1 = 10000000 * MIN_VALID_PROOF_SCORE;
+    Score score1 = 100000 * MIN_VALID_PROOF_SCORE;
     auto proof1 = buildRandomProof(active_chainstate, score1);
     PeerId peerid1 = TestPeerManager::registerAndGetPeerId(pm, proof1);
     checkScores(score1, 0);

--- a/src/avalanche/test/proof_tests.cpp
+++ b/src/avalanche/test/proof_tests.cpp
@@ -635,7 +635,18 @@ BOOST_AUTO_TEST_CASE(deserialization) {
         BOOST_CHECK_EQUAL(p.getScore(), c.score);
 
         ProofValidationState state;
-        BOOST_CHECK_EQUAL(p.verify(PROOF_DUST_THRESHOLD, state),
+        /**
+         * TODO: Redo test cases using new PROOF_DUST_THRESHOLD
+         * Process for updating these:
+         *  * Bump the below value to PROOF_DUST_THRESHOLD
+         *  * Take note of failing test cases. Decode them so you can copy as
+         *    many details as possible.
+         *  * Prepare up to 4 UTXOs (regtest!)
+         *  * Prepare proofs using the master key and payout address above
+         *  * Replace each failing test cases' hex and proofid (and score as
+         *    needed). Result should remain unmodified.
+         */
+        BOOST_CHECK_EQUAL(p.verify(100 * COIN, state),
                           c.result == ProofValidationResult::NONE);
         BOOST_CHECK(state.GetResult() == c.result);
         BOOST_TEST_MESSAGE(c.proofid);


### PR DESCRIPTION
Notes:
* Min quorum is adjusted to be ~$200,000 at today's prices, similar to eCash
* Proof dust threshold is adjusted to be ~$2000, similar to eCash
* Stake UTXO confirmations adjusted in line with dogecoin's faster block schedule to maintain a 2 week UTXO age requirement

I had considered higher quorum and dust threshold numbers given dogecoin's market cap, but the number of public nodes on the network is only ~4x that of eCash. Making those limits too high could prove prohibitive. We can adjust more as needed.