### PR TITLE
Fix off-by-one when calculating DAA params

### DIFF
--- a/src/pow/pow.cpp
+++ b/src/pow/pow.cpp
@@ -47,7 +47,7 @@ uint32_t GetNextWorkRequired(const CBlockIndex *pindexPrev,
         UintToArith256(params.powLimit).GetCompact();
 
     const int32_t nHeight = pindexPrev->nHeight;
-    const Consensus::DaaParams daaParams = params.DaaParamsAtHeight(nHeight);
+    const Consensus::DaaParams daaParams = params.DaaParamsAtHeight(nHeight + 1);
 
     // Dogecoin: Special rules for minimum difficulty blocks with Digishield
     if (nHeight >= 157500 && AllowDigishieldMinDifficultyForBlock(pindexPrev, pblock, params,


### PR DESCRIPTION
This has no impact on mainnet but it does fix validating the current testnet chain.