### PR TITLE
Stratum v1 mining server core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 The Bitcoin developers
+# Copyright (c) 2025-2026 Tobias Ruck and Alexandre Guillioud
 
 cmake_minimum_required(VERSION 3.18)
 

--- a/pr-dependency-graph.html
+++ b/pr-dependency-graph.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>doged PR Dependency Graph</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600;700&family=Anybody:wght@700;900&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+html,body{width:100%;height:100%;overflow:hidden}
+body{
+  background:#08090d;
+  color:#c9d1d9;
+  font-family:'IBM Plex Mono',monospace;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:center;
+  padding:32px;
+}
+.header{text-align:center;margin-bottom:36px}
+.header h1{
+  font-family:'Anybody',sans-serif;font-weight:900;font-size:32px;
+  letter-spacing:-1px;
+  background:linear-gradient(135deg,#58a6ff,#3fb950);
+  -webkit-background-clip:text;-webkit-text-fill-color:transparent;
+}
+.header p{color:#484f58;font-size:12px;margin-top:6px;letter-spacing:1px}
+svg{width:820px;height:440px;filter:drop-shadow(0 0 80px rgba(88,166,255,0.06))}
+.edge{stroke:#21262d;stroke-width:2;fill:none}
+.edge-active{stroke:#30363d;stroke-width:2;fill:none}
+.edge-draft{stroke:#21262d;stroke-width:1.5;fill:none;stroke-dasharray:6 4}
+.dot{fill:#30363d}.dot-active{fill:#58a6ff}
+.card{filter:drop-shadow(0 2px 8px rgba(0,0,0,0.3))}
+.card rect{rx:10;ry:10}
+.card-open rect{fill:#0d1117;stroke:#3fb950;stroke-width:2}
+.card-ready rect{fill:#0d1117;stroke:#58a6ff;stroke-width:2}
+.card-queued rect{fill:#0d1117;stroke:#21262d;stroke-width:1.5}
+.card-draft rect{fill:#0d1117;stroke:#21262d;stroke-width:1.5;stroke-dasharray:6 4}
+.pr-label{font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:700;letter-spacing:0.5px;text-transform:uppercase}
+.pr-title{font-family:'IBM Plex Mono',monospace;font-size:12px;font-weight:600;fill:#e6edf3}
+.pr-sub{font-family:'IBM Plex Mono',monospace;font-size:10px;fill:#484f58}
+.legend{margin-top:28px;display:flex;gap:24px}
+.legend-item{display:flex;align-items:center;gap:8px;font-size:11px;color:#484f58}
+.legend-dot{width:10px;height:10px;border-radius:3px}
+.legend-dot.open{background:#3fb950}
+.legend-dot.ready{background:#58a6ff}
+.legend-dot.queued{background:#21262d;border:1px solid #30363d}
+.legend-dot.draft{background:transparent;border:1.5px dashed #30363d}
+</style>
+</head>
+<body>
+<div class="header">
+  <h1>doged PR Stack</h1>
+  <p>FRENCHBTC/DOGED &rarr; DOGED-IO/DOGED</p>
+</div>
+<svg viewBox="0 0 820 440">
+  <!-- Edges -->
+  <path class="edge-active" d="M 330 72 L 330 108"/>
+  <circle class="dot-active" cx="330" cy="108" r="3"/>
+  <path class="edge" d="M 410 52 Q 540 52 620 80 L 620 108"/>
+  <circle class="dot" cx="620" cy="108" r="3"/>
+  <path class="edge" d="M 410 52 Q 600 42 740 80 L 740 108"/>
+  <circle class="dot" cx="740" cy="108" r="3"/>
+  <path class="edge-draft" d="M 250 52 Q 140 52 100 80 L 100 108"/>
+  <circle class="dot" cx="100" cy="108" r="3"/>
+  <path class="edge-active" d="M 330 180 L 330 218"/>
+  <circle class="dot-active" cx="330" cy="218" r="3"/>
+  <path class="edge-active" d="M 330 290 L 330 328"/>
+  <circle class="dot-active" cx="330" cy="328" r="3"/>
+
+  <!-- PR1 -->
+  <g class="card card-open" transform="translate(220,0)">
+    <rect width="220" height="68"/>
+    <text class="pr-label" x="16" y="22" fill="#3fb950">PR1</text>
+    <text class="pr-title" x="16" y="42">Stratum v1 core</text>
+    <text class="pr-sub" x="16" y="58">#102 &#x2022; open</text>
+  </g>
+  <!-- PR2 draft -->
+  <g class="card card-draft" transform="translate(10,112)">
+    <rect width="180" height="68"/>
+    <text class="pr-label" x="14" y="22" fill="#484f58">PR2</text>
+    <text class="pr-title" x="14" y="42" fill="#484f58">Proxy + routing</text>
+    <text class="pr-sub" x="14" y="58">draft &#x2022; deferred</text>
+  </g>
+  <!-- PR3 -->
+  <g class="card card-ready" transform="translate(220,112)">
+    <rect width="220" height="68"/>
+    <text class="pr-label" x="16" y="22" fill="#58a6ff">PR3</text>
+    <text class="pr-title" x="16" y="42">AuxPoW RPCs</text>
+    <text class="pr-sub" x="16" y="58">#103 &#x2022; open</text>
+  </g>
+  <!-- PR4 -->
+  <g class="card card-ready" transform="translate(220,222)">
+    <rect width="220" height="68"/>
+    <text class="pr-label" x="16" y="22" fill="#58a6ff">PR4</text>
+    <text class="pr-title" x="16" y="42">Multi-chain merge-mine</text>
+    <text class="pr-sub" x="16" y="58">#104 &#x2022; open</text>
+  </g>
+  <!-- PR5 -->
+  <g class="card card-ready" transform="translate(190,332)">
+    <rect width="280" height="68"/>
+    <text class="pr-label" x="16" y="22" fill="#58a6ff">PR5</text>
+    <text class="pr-title" x="16" y="42">Per-chain target + AuxPoW</text>
+    <text class="pr-sub" x="16" y="58">#105 &#x2022; open</text>
+  </g>
+  <!-- PR6 draft -->
+  <g class="card card-draft" transform="translate(500,332)">
+    <rect width="180" height="68"/>
+    <text class="pr-label" x="14" y="22" fill="#484f58">PR6</text>
+    <text class="pr-title" x="14" y="42" fill="#484f58">SQLite analytics</text>
+    <text class="pr-sub" x="14" y="58">draft &#x2022; separate branch</text>
+  </g>
+  <!-- PR7 -->
+  <g class="card card-queued" transform="translate(530,112)">
+    <rect width="180" height="68"/>
+    <text class="pr-label" x="14" y="22" fill="#30363d">PR7</text>
+    <text class="pr-title" x="14" y="42" fill="#6e7681">REST API + dashboard</text>
+    <text class="pr-sub" x="14" y="58">queued</text>
+  </g>
+  <!-- PR8 -->
+  <g class="card card-queued" transform="translate(650,222)">
+    <rect width="160" height="68"/>
+    <text class="pr-label" x="14" y="22" fill="#30363d">PR8</text>
+    <text class="pr-title" x="14" y="42" fill="#6e7681">Miner tool</text>
+    <text class="pr-sub" x="14" y="58">queued</text>
+  </g>
+</svg>
+<div class="legend">
+  <div class="legend-item"><div class="legend-dot open"></div>Open upstream</div>
+  <div class="legend-item"><div class="legend-dot ready"></div>Open (stacked)</div>
+  <div class="legend-item"><div class="legend-dot queued"></div>Queued</div>
+  <div class="legend-item"><div class="legend-dot draft"></div>Draft / deferred</div>
+</div>
+</body>
+</html>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 The Bitcoin developers
+# Copyright (c) 2025-2026 Tobias Ruck and Alexandre Guillioud
 
 project(doged)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -692,6 +692,13 @@ add_library(server
 	pow/auxpow.cpp
 	pow/pow.cpp
 	rest.cpp
+	stratum/stratum.cpp
+	stratum/stratumconfig.cpp
+	stratum/stratumjob.cpp
+	stratum/stratumprotocol.cpp
+	stratum/stratumstats.cpp
+	stratum/stratumsubmit.cpp
+	stratum/stratumworker.cpp
 	rpc/abc.cpp
 	rpc/avalanche.cpp
 	rpc/blockchain.cpp
@@ -762,6 +769,7 @@ endif()
 add_subdirectory(test)
 add_subdirectory(avalanche/test)
 add_subdirectory(pow/test)
+add_subdirectory(stratum/test)
 
 # Benchmark suite.
 add_subdirectory(bench)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -64,6 +64,8 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <scheduler.h>
+#include <stratum/stratum.h>
+#include <stratum/stratumconfig.h>
 #include <script/scriptcache.h>
 #include <script/sigcache.h>
 #include <script/standard.h>
@@ -205,6 +207,7 @@ void Interrupt(NodeContext &node) {
     InterruptHTTPRPC();
     InterruptRPC();
     InterruptREST();
+    stratum::InterruptStratumServer();
     InterruptTorControl();
     InterruptMapPort();
     if (node.avalanche) {
@@ -245,6 +248,7 @@ void Shutdown(NodeContext &node) {
     StopHTTPRPC();
     StopREST();
     StopRPC();
+    stratum::StopStratumServer();
     StopHTTPServer();
     for (const auto &client : node.chain_clients) {
         client->flush();
@@ -1278,6 +1282,8 @@ void SetupServerArgs(NodeContext &node) {
                    ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY,
                    OptionsCategory::BLOCK_CREATION);
 
+    stratum::RegisterStratumArgs(argsman);
+
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands",
                    ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rest",
@@ -1562,6 +1568,14 @@ static bool AppInitServers(Config &config,
     }
 
     StartHTTPServer();
+
+    // Initialize Stratum mining server if enabled
+    auto stratumConfig = stratum::ParseStratumConfig(args);
+    if (stratumConfig && stratumConfig->enabled) {
+        LogPrintf("Stratum server configured on %s:%d\n",
+                  stratumConfig->bind, stratumConfig->port);
+    }
+
     return true;
 }
 
@@ -3054,6 +3068,22 @@ bool AppInitMain(Config &config, RPCServer &rpcServer,
     SetRPCWarmupFinished();
 
     uiInterface.InitMessage(_("Done loading").translated);
+
+    // Start Stratum server now that chainstate is fully loaded
+    {
+        auto stratumConfig = stratum::ParseStratumConfig(args);
+        if (stratumConfig && stratumConfig->enabled) {
+            if (!stratum::InitStratumServer(
+                    *stratumConfig,
+                    chainman.ActiveChainstate(),
+                    node.mempool.get(),
+                    chainparams,
+                    chainman)) {
+                return InitError(_("Failed to initialize Stratum server."));
+            }
+            stratum::StartStratumServer();
+        }
+    }
 
     for (const auto &client : node.chain_clients) {
         client->start(*node.scheduler);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1569,13 +1569,6 @@ static bool AppInitServers(Config &config,
 
     StartHTTPServer();
 
-    // Initialize Stratum mining server if enabled
-    auto stratumConfig = stratum::ParseStratumConfig(args);
-    if (stratumConfig && stratumConfig->enabled) {
-        LogPrintf("Stratum server configured on %s:%d\n",
-                  stratumConfig->bind, stratumConfig->port);
-    }
-
     return true;
 }
 
@@ -3073,6 +3066,8 @@ bool AppInitMain(Config &config, RPCServer &rpcServer,
     {
         auto stratumConfig = stratum::ParseStratumConfig(args);
         if (stratumConfig && stratumConfig->enabled) {
+            LogPrintf("Stratum server configured on %s:%d\n",
+                      stratumConfig->bind, stratumConfig->port);
             if (!stratum::InitStratumServer(
                     *stratumConfig,
                     chainman.ActiveChainstate(),

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Copyright (c) 2017-2019 The Bitcoin developers
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -132,6 +132,7 @@ static const std::map<std::string, BCLog::LogFlags> LOG_CATEGORIES_BY_STR{
     {"blockstorage", BCLog::BLOCKSTORE},
     {"netdebug", BCLog::NETDEBUG},
     {"txpackages", BCLog::TXPACKAGES},
+    {"stratum", BCLog::STRATUM},
     {"1", BCLog::ALL},
     {"all", BCLog::ALL},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -69,6 +69,7 @@ enum LogFlags : uint32_t {
     BLOCKSTORE = (1 << 26),
     NETDEBUG = (1 << 27),
     TXPACKAGES = (1 << 28),
+    STRATUM = (1 << 29),
     ALL = ~uint32_t(0),
 };
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Copyright (c) 2017-2019 The Bitcoin developers
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1,6 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2018 The Bitcoin Core developers
-// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -1,0 +1,811 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratum.h>
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <key_io.h>
+#include <logging.h>
+#include <pow/pow.h>
+#include <script/standard.h>
+#include <shutdown.h>
+#include <util/strencodings.h>
+#include <util/time.h>
+#include <validation.h>
+
+#include <event2/buffer.h>
+#include <event2/bufferevent.h>
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/thread.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+namespace stratum {
+
+static std::unique_ptr<StratumServer> g_stratumServer;
+
+// --- StratumServer ---
+
+StratumServer::StratumServer(const StratumConfig &config,
+                             Chainstate &chainstate,
+                             const CTxMemPool *mempool,
+                             const CChainParams &chainParams,
+                             ChainstateManager &chainman)
+    : m_config(config), m_chainstate(chainstate), m_chainParams(chainParams),
+      m_chainman(chainman) {
+
+    // Determine coinbase script
+    CScript coinbaseScript;
+    if (!m_config.coinbaseAddress.empty()) {
+        CTxDestination dest =
+            DecodeDestination(m_config.coinbaseAddress, chainParams);
+        if (IsValidDestination(dest)) {
+            coinbaseScript = GetScriptForDestination(dest);
+        }
+    }
+    if (coinbaseScript.empty()) {
+        coinbaseScript = CScript() << OP_TRUE;
+    }
+
+    // Build upstream pool list from config
+    std::vector<UpstreamPool> pools;
+    for (const auto &entry : m_config.upstreamPools) {
+        UpstreamPool pool;
+        pool.host = entry.host;
+        pool.port = entry.port;
+        pool.username = entry.username;
+        pool.password = entry.password;
+        pool.priority = entry.priority;
+        pools.push_back(pool);
+    }
+
+    m_router = std::make_unique<StratumRouter>(
+        config, pools, chainstate, mempool, chainParams, chainman,
+        coinbaseScript);
+
+    m_auxMgr = std::make_unique<StratumAuxManager>(
+        chainstate, mempool, chainParams, coinbaseScript);
+}
+
+StratumServer::~StratumServer() {
+    Stop();
+}
+
+bool StratumServer::Start() {
+    m_startTime = GetTime();
+
+    // Thread-safety: BroadcastJob/BroadcastRawNotify are called from the
+    // validation thread while the event loop runs on m_eventThread.
+    evthread_use_pthreads();
+
+    m_eventBase = event_base_new();
+    if (!m_eventBase) {
+        LogPrintf("Stratum: failed to create event base\n");
+        return false;
+    }
+
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof(sin));
+    sin.sin_family = AF_INET;
+    sin.sin_port = htons(m_config.port);
+    if (inet_pton(AF_INET, m_config.bind.c_str(), &sin.sin_addr) <= 0) {
+        sin.sin_addr.s_addr = INADDR_ANY;
+    }
+
+    m_listener = evconnlistener_new_bind(
+        m_eventBase, OnAccept, this,
+        LEV_OPT_REUSEABLE | LEV_OPT_CLOSE_ON_FREE, -1,
+        (struct sockaddr *)&sin, sizeof(sin));
+
+    if (!m_listener) {
+        LogPrintf("Stratum: failed to bind to %s:%d\n", m_config.bind,
+                  m_config.port);
+        event_base_free(m_eventBase);
+        m_eventBase = nullptr;
+        return false;
+    }
+
+    m_running.store(true);
+    m_interrupt.store(false);
+
+    // Wire router callbacks so it can push data to our miners
+    RouterDownstreamCallbacks routerCbs;
+    routerCbs.broadcastNotify = [this](const std::string &raw) {
+        BroadcastRawNotify(raw);
+    };
+    routerCbs.broadcastDifficulty = [this](double diff) {
+        BroadcastDifficultyAll(diff);
+    };
+    routerCbs.submitResult = [this](int64_t minerId, bool accepted,
+                                     const std::string &error) {
+        HandleProxySubmitResult(minerId, accepted, error);
+    };
+    routerCbs.tierChanged = [this](RoutingTier tier,
+                                    const std::string &detail) {
+        LogPrintf("Stratum: routing tier → %s (%s)\n",
+                  TierName(tier), detail);
+    };
+    m_router->SetCallbacks(std::move(routerCbs));
+
+    // Start the router (connects proxies, evaluates tiers)
+    if (!m_router->Start()) {
+        LogPrintf("Stratum: failed to start router\n");
+    }
+
+    // Register for chain tip notifications
+    RegisterValidationInterface(this);
+
+    // Register stats HTTP endpoint
+    RegisterStratumHTTPHandlers([this]() { return GetStats(); });
+
+    // Start event loop in a background thread
+    m_eventThread = std::thread([this]() { EventLoop(); });
+
+    LogPrintf("Stratum: server started on %s:%d (tier: %s)\n",
+              m_config.bind, m_config.port,
+              TierName(m_router->GetActiveTier()));
+
+    return true;
+}
+
+void StratumServer::Interrupt() {
+    m_interrupt.store(true);
+    if (m_eventBase) {
+        event_base_loopbreak(m_eventBase);
+    }
+}
+
+void StratumServer::Stop() {
+    if (!m_running.load()) {
+        return;
+    }
+
+    Interrupt();
+
+    if (m_eventThread.joinable()) {
+        m_eventThread.join();
+    }
+
+    if (m_router) {
+        m_router->Stop();
+    }
+
+    UnregisterValidationInterface(this);
+    UnregisterStratumHTTPHandlers();
+
+    {
+        LOCK(m_cs);
+        for (auto &[id, session] : m_sessions) {
+            if (session->bev) {
+                bufferevent_free(session->bev);
+                session->bev = nullptr;
+            }
+        }
+        m_sessions.clear();
+    }
+
+    if (m_listener) {
+        evconnlistener_free(m_listener);
+        m_listener = nullptr;
+    }
+
+    if (m_eventBase) {
+        event_base_free(m_eventBase);
+        m_eventBase = nullptr;
+    }
+
+    m_running.store(false);
+
+    LogPrintf("Stratum: server stopped\n");
+}
+
+void StratumServer::EventLoop() {
+    while (!m_interrupt.load() && !ShutdownRequested()) {
+        // Run event loop with a 1-second timeout for periodic checks
+        struct timeval tv = {1, 0};
+        event_base_loopexit(m_eventBase, &tv);
+        event_base_dispatch(m_eventBase);
+
+        if (!m_interrupt.load() && !ShutdownRequested()) {
+            PeriodicMaintenance();
+        }
+    }
+}
+
+// --- libevent callbacks ---
+
+void StratumServer::OnAccept(struct evconnlistener *, int fd,
+                              struct sockaddr *addr, int, void *ctx) {
+    auto *server = static_cast<StratumServer *>(ctx);
+    server->HandleAccept(fd, addr);
+}
+
+void StratumServer::OnRead(struct bufferevent *bev, void *ctx) {
+    auto *pair = static_cast<std::pair<StratumServer *, uint32_t> *>(ctx);
+    pair->first->HandleRead(pair->second);
+}
+
+void StratumServer::OnEvent(struct bufferevent *bev, short events, void *ctx) {
+    auto *pair = static_cast<std::pair<StratumServer *, uint32_t> *>(ctx);
+    if (events & (BEV_EVENT_ERROR | BEV_EVENT_EOF | BEV_EVENT_TIMEOUT)) {
+        pair->first->HandleDisconnect(pair->second);
+        delete pair;
+    }
+}
+
+void StratumServer::HandleAccept(int fd, struct sockaddr *addr) {
+    LOCK(m_cs);
+
+    if ((int)m_sessions.size() >= m_config.maxWorkers) {
+        close(fd);
+        LogPrint(BCLog::STRATUM, "Stratum: rejected connection (max workers)\n");
+        return;
+    }
+
+    uint32_t sessionId = m_nextSessionId++;
+    std::string extranonce1 = m_extranonceMgr.Next();
+
+    auto session = std::make_unique<ClientSession>();
+    session->sessionId = sessionId;
+    session->worker = std::make_unique<StratumWorker>(
+        sessionId, extranonce1, m_config.defaultDifficulty);
+
+    struct bufferevent *bev =
+        bufferevent_socket_new(m_eventBase, fd,
+                               BEV_OPT_CLOSE_ON_FREE | BEV_OPT_THREADSAFE);
+    session->bev = bev;
+
+    // Store context for callbacks
+    auto *cbCtx = new std::pair<StratumServer *, uint32_t>(this, sessionId);
+    bufferevent_setcb(bev, OnRead, nullptr, OnEvent, cbCtx);
+    bufferevent_enable(bev, EV_READ | EV_WRITE);
+
+    struct timeval tv = {m_config.workerTimeoutSec, 0};
+    bufferevent_set_timeouts(bev, &tv, nullptr);
+
+    m_sessions[sessionId] = std::move(session);
+    m_totalConnections++;
+
+    char addrStr[INET_ADDRSTRLEN] = {};
+    if (addr && addr->sa_family == AF_INET) {
+        inet_ntop(AF_INET, &((struct sockaddr_in *)addr)->sin_addr, addrStr,
+                  sizeof(addrStr));
+    }
+    LogPrint(BCLog::STRATUM, "Stratum: new connection #%d from %s\n",
+             sessionId, addrStr);
+}
+
+void StratumServer::HandleRead(uint32_t sessionId) {
+    LOCK(m_cs);
+    auto it = m_sessions.find(sessionId);
+    if (it == m_sessions.end()) {
+        return;
+    }
+    auto &session = *it->second;
+
+    struct evbuffer *input = bufferevent_get_input(session.bev);
+    size_t len = evbuffer_get_length(input);
+    if (len == 0) {
+        return;
+    }
+
+    std::vector<char> buf(len);
+    evbuffer_remove(input, buf.data(), len);
+
+    session.lineBuffer.Append(buf.data(), len);
+
+    if (session.lineBuffer.OverflowDetected()) {
+        LogPrint(BCLog::STRATUM, "Stratum: line overflow from #%d\n",
+                 sessionId);
+        HandleDisconnect(sessionId);
+        return;
+    }
+
+    auto lines = session.lineBuffer.ExtractLines();
+    for (const auto &line : lines) {
+        auto msgResult = ParseStratumLine(line);
+        if (msgResult) {
+            ProcessMessage(session, *msgResult);
+        }
+    }
+
+    session.worker->Touch(GetTime());
+}
+
+void StratumServer::HandleDisconnect(uint32_t sessionId) {
+    LOCK(m_cs);
+    auto it = m_sessions.find(sessionId);
+    if (it == m_sessions.end()) {
+        return;
+    }
+
+    if (it->second->bev) {
+        bufferevent_free(it->second->bev);
+        it->second->bev = nullptr;
+    }
+    m_sessions.erase(it);
+
+    LogPrint(BCLog::STRATUM, "Stratum: client #%d disconnected\n", sessionId);
+}
+
+void StratumServer::ProcessMessage(ClientSession &session,
+                                    const StratumMessage &msg) {
+    if (auto *req = std::get_if<StratumRequest>(&msg)) {
+        if (req->method == "mining.subscribe") {
+            HandleSubscribe(session, *req);
+        } else if (req->method == "mining.authorize") {
+            HandleAuthorize(session, *req);
+        } else if (req->method == "mining.submit") {
+            HandleSubmit(session, *req);
+        } else {
+            // Unknown method
+            UniValue err(UniValue::VARR);
+            err.push_back(20);
+            err.push_back("Unknown method");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req->id, UniValue(UniValue::VNULL), err);
+        }
+    }
+    // Notifications and responses from client are ignored
+}
+
+void StratumServer::HandleSubscribe(ClientSession &session,
+                                     const StratumRequest &req) {
+    auto result = session.worker->HandleSubscribe(req.params);
+    if (!result) {
+        UniValue err(UniValue::VARR);
+        err.push_back(25);
+        err.push_back(util::ErrorString(result).original);
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(UniValue::VNULL), err);
+        return;
+    }
+    SendResponse(session, req.id, *result, UniValue(UniValue::VNULL));
+}
+
+void StratumServer::HandleAuthorize(ClientSession &session,
+                                     const StratumRequest &req) {
+    auto result = session.worker->HandleAuthorize(req.params);
+    if (!result) {
+        UniValue err(UniValue::VARR);
+        err.push_back(24);
+        err.push_back(util::ErrorString(result).original);
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(UniValue::VNULL), err);
+        return;
+    }
+    SendResponse(session, req.id, *result, UniValue(UniValue::VNULL));
+
+    // Send initial difficulty
+    SendDifficulty(session.sessionId, m_config.defaultDifficulty);
+
+    // Send current job if in local mode
+    if (m_router && m_router->GetActiveTier() == RoutingTier::LOCAL) {
+        auto *jobMgr = m_router->GetJobManager();
+        if (jobMgr && jobMgr->JobCount() > 0) {
+            auto jobResult = jobMgr->CreateJob(false);
+            if (jobResult) {
+                UniValue notifyParams =
+                    jobMgr->FormatNotifyParams(*jobResult);
+                std::string data =
+                    SerializeNotify("mining.notify", notifyParams);
+                SendToClient(session, data);
+            }
+        }
+    }
+    // In proxy mode, the next upstream mining.notify will be relayed
+}
+
+void StratumServer::HandleSubmit(ClientSession &session,
+                                  const StratumRequest &req) {
+    if (session.worker->GetState() != StratumWorker::State::AUTHORIZED) {
+        UniValue err(UniValue::VARR);
+        err.push_back(StratumError::UNAUTHORIZED);
+        err.push_back("Not authorized");
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(UniValue::VNULL), err);
+        return;
+    }
+
+    RoutingTier tier = m_router ? m_router->GetActiveTier()
+                                : RoutingTier::NONE;
+
+    // --- Proxy mode: forward upstream, response comes via callback ---
+    if (tier == RoutingTier::PROXY) {
+        // We're already under m_cs from HandleRead → ProcessMessage
+        m_pendingProxySubmits[req.id] = session.sessionId;
+        if (!m_router->RouteSubmit(req.id, 0, "", req.params, nullptr)) {
+            m_pendingProxySubmits.erase(req.id);
+            UniValue err(UniValue::VARR);
+            err.push_back(20);
+            err.push_back("No upstream available");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req.id, UniValue(false), err);
+        }
+        return;
+    }
+
+    // --- Local mode: validate share locally ---
+    if (tier == RoutingTier::NONE) {
+        UniValue err(UniValue::VARR);
+        err.push_back(20);
+        err.push_back("No mining backend available");
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(false), err);
+        return;
+    }
+
+    auto subResult = ParseSubmitParams(req.params);
+    if (!subResult) {
+        UniValue err(UniValue::VARR);
+        err.push_back(20);
+        err.push_back(util::ErrorString(subResult).original);
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(false), err);
+        return;
+    }
+
+    auto *jobMgr = m_router->GetJobManager();
+    const StratumJob *job = jobMgr ? jobMgr->GetJob(subResult->jobId)
+                                    : nullptr;
+    if (!job) {
+        session.worker->RecordShareStale();
+        m_totalSharesStale++;
+        UniValue err(UniValue::VARR);
+        err.push_back(StratumError::JOB_NOT_FOUND);
+        err.push_back("Job not found");
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, req.id, UniValue(false), err);
+        return;
+    }
+
+    ShareResult result = ValidateShare(
+        *job, session.worker->GetExtranonce1(), *subResult,
+        session.worker->GetCurrentDifficulty(),
+        m_chainParams.GetConsensus(), session.submittedNonces);
+
+    switch (result) {
+        case ShareResult::ACCEPTED_BLOCK:
+            session.worker->RecordShareAccepted(
+                session.worker->GetCurrentDifficulty());
+            m_totalSharesAccepted++;
+            m_blocksFound++;
+            SendResponse(session, req.id, UniValue(true),
+                         UniValue(UniValue::VNULL));
+
+            SubmitBlock(*job, session.worker->GetExtranonce1(), *subResult,
+                        m_chainman, m_chainParams);
+
+            LogPrintf("Stratum: BLOCK FOUND by worker %s at height %d!\n",
+                      session.worker->GetWorkerName(), job->height);
+            break;
+
+        case ShareResult::ACCEPTED:
+            session.worker->RecordShareAccepted(
+                session.worker->GetCurrentDifficulty());
+            m_totalSharesAccepted++;
+            SendResponse(session, req.id, UniValue(true),
+                         UniValue(UniValue::VNULL));
+            break;
+
+        case ShareResult::REJECTED_LOW_DIFF: {
+            session.worker->RecordShareRejected();
+            m_totalSharesRejected++;
+            UniValue err(UniValue::VARR);
+            err.push_back(StratumError::LOW_DIFFICULTY);
+            err.push_back("Low difficulty share");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req.id, UniValue(false), err);
+            break;
+        }
+
+        case ShareResult::REJECTED_DUPLICATE: {
+            session.worker->RecordShareRejected();
+            m_totalSharesRejected++;
+            UniValue err(UniValue::VARR);
+            err.push_back(StratumError::DUPLICATE_SHARE);
+            err.push_back("Duplicate share");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req.id, UniValue(false), err);
+            break;
+        }
+
+        case ShareResult::REJECTED_STALE: {
+            session.worker->RecordShareStale();
+            m_totalSharesStale++;
+            UniValue err(UniValue::VARR);
+            err.push_back(StratumError::JOB_NOT_FOUND);
+            err.push_back("Stale share");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req.id, UniValue(false), err);
+            break;
+        }
+
+        case ShareResult::REJECTED_INVALID: {
+            session.worker->RecordShareRejected();
+            m_totalSharesRejected++;
+            UniValue err(UniValue::VARR);
+            err.push_back(20);
+            err.push_back("Invalid share");
+            err.push_back(UniValue(UniValue::VNULL));
+            SendResponse(session, req.id, UniValue(false), err);
+            break;
+        }
+    }
+}
+
+void StratumServer::SendToClient(ClientSession &session,
+                                  const std::string &data) {
+    if (!session.bev) {
+        return;
+    }
+    bufferevent_write(session.bev, data.data(), data.size());
+}
+
+void StratumServer::SendResponse(ClientSession &session, int64_t id,
+                                  const UniValue &result,
+                                  const UniValue &error) {
+    SendToClient(session, SerializeResponse(id, result, error));
+}
+
+void StratumServer::BroadcastJob(const StratumJob &job) {
+    auto *jobMgr = m_router ? m_router->GetJobManager() : nullptr;
+    if (!jobMgr) {
+        return;
+    }
+    LOCK(m_cs);
+    UniValue notifyParams = jobMgr->FormatNotifyParams(job);
+    std::string data = SerializeNotify("mining.notify", notifyParams);
+
+    for (auto &[id, session] : m_sessions) {
+        if (session->worker->GetState() == StratumWorker::State::AUTHORIZED) {
+            SendToClient(*session, data);
+        }
+    }
+}
+
+void StratumServer::BroadcastRawNotify(const std::string &rawLine) {
+    LOCK(m_cs);
+    for (auto &[id, session] : m_sessions) {
+        if (session->worker->GetState() == StratumWorker::State::AUTHORIZED) {
+            SendToClient(*session, rawLine);
+        }
+    }
+}
+
+void StratumServer::BroadcastDifficultyAll(double difficulty) {
+    LOCK(m_cs);
+    UniValue params(UniValue::VARR);
+    params.push_back(difficulty);
+    std::string data = SerializeNotify("mining.set_difficulty", params);
+    for (auto &[id, session] : m_sessions) {
+        if (session->worker->GetState() == StratumWorker::State::AUTHORIZED) {
+            SendToClient(*session, data);
+        }
+    }
+}
+
+void StratumServer::HandleProxySubmitResult(int64_t minerId, bool accepted,
+                                             const std::string &error) {
+    LOCK(m_cs);
+    // Find the session that issued this submit
+    auto pendingIt = m_pendingProxySubmits.find(minerId);
+    if (pendingIt == m_pendingProxySubmits.end()) {
+        return;
+    }
+    uint32_t sessionId = pendingIt->second;
+    m_pendingProxySubmits.erase(pendingIt);
+
+    auto sessionIt = m_sessions.find(sessionId);
+    if (sessionIt == m_sessions.end()) {
+        return;
+    }
+
+    auto &session = *sessionIt->second;
+    if (accepted) {
+        session.worker->RecordShareAccepted(
+            session.worker->GetCurrentDifficulty());
+        m_totalSharesAccepted++;
+        SendResponse(session, minerId, UniValue(true),
+                     UniValue(UniValue::VNULL));
+    } else {
+        session.worker->RecordShareRejected();
+        m_totalSharesRejected++;
+        UniValue err(UniValue::VARR);
+        err.push_back(20);
+        err.push_back(error.empty() ? "Rejected by upstream" : error);
+        err.push_back(UniValue(UniValue::VNULL));
+        SendResponse(session, minerId, UniValue(false), err);
+    }
+}
+
+void StratumServer::SendDifficulty(uint32_t sessionId, double difficulty) {
+    LOCK(m_cs);
+    auto it = m_sessions.find(sessionId);
+    if (it == m_sessions.end()) {
+        return;
+    }
+
+    UniValue params(UniValue::VARR);
+    params.push_back(difficulty);
+    std::string data = SerializeNotify("mining.set_difficulty", params);
+    SendToClient(*it->second, data);
+}
+
+StratumServerStats StratumServer::GetStats() const {
+    StratumServerStats stats;
+    stats.startTime = m_startTime;
+    stats.totalConnections = m_totalConnections.load();
+    stats.totalSharesAccepted = m_totalSharesAccepted.load();
+    stats.totalSharesRejected = m_totalSharesRejected.load();
+    stats.totalSharesStale = m_totalSharesStale.load();
+    stats.blocksFound = m_blocksFound.load();
+
+    {
+        LOCK(m_cs);
+        stats.activeWorkers = m_sessions.size();
+        for (const auto &[id, session] : m_sessions) {
+            stats.workers.push_back(session->worker->GetStats());
+        }
+    }
+
+    // Routing info
+    if (m_router) {
+        stats.activeTier = TierName(m_router->GetActiveTier());
+        stats.activeProxyIndex = m_router->GetActiveProxyIndex();
+        for (size_t i = 0; i < m_router->GetProxyCount(); ++i) {
+            ProxyHealth h = m_router->GetProxyHealth(i);
+            UpstreamPoolStats ps;
+            ps.label = m_config.upstreamPools.size() > i
+                           ? (m_config.upstreamPools[i].host + ":" +
+                              std::to_string(m_config.upstreamPools[i].port))
+                           : "unknown";
+            ps.connected = h.connected;
+            ps.healthy = h.connected && h.authorized &&
+                         h.consecutiveErrors < 5;
+            ps.priority = m_config.upstreamPools.size() > i
+                              ? m_config.upstreamPools[i].priority
+                              : 0;
+            ps.consecutiveErrors = h.consecutiveErrors;
+            ps.lastError = h.lastError;
+            stats.upstreamPools.push_back(ps);
+        }
+    }
+
+    // Network difficulty from chain tip
+    LOCK(cs_main);
+    const CBlockIndex *tip = m_chainstate.m_chain.Tip();
+    if (tip) {
+        stats.chainHeight = tip->nHeight;
+        arith_uint256 target;
+        if (NBitsToTarget(m_chainParams.GetConsensus(), tip->nBits, target) &&
+            target > arith_uint256(0)) {
+            arith_uint256 diff1;
+            diff1.SetCompact(0x1d00ffff);
+            stats.networkDifficulty =
+                diff1.getdouble() / target.getdouble();
+        }
+    }
+
+    return stats;
+}
+
+size_t StratumServer::GetWorkerCount() const {
+    LOCK(m_cs);
+    return m_sessions.size();
+}
+
+void StratumServer::UpdatedBlockTip(const CBlockIndex *pindexNew,
+                                     const CBlockIndex *,
+                                     bool fInitialDownload) {
+    if (fInitialDownload) {
+        return;
+    }
+    if (!m_running.load()) {
+        return;
+    }
+
+    LogPrint(BCLog::STRATUM, "Stratum: new tip at height %d\n",
+             pindexNew->nHeight);
+
+    // Delegate to the router — it decides whether to create a local job
+    // or whether a proxy is handling notifications.
+    if (m_router) {
+        m_router->OnNewTip(pindexNew->nHeight);
+    }
+}
+
+void StratumServer::CreateAndBroadcastJob(bool cleanJobs) {
+    // Delegate to router for local-mode job creation
+    if (m_router && m_router->GetActiveTier() == RoutingTier::LOCAL) {
+        auto *jobMgr = m_router->GetJobManager();
+        if (!jobMgr) {
+            return;
+        }
+        auto jobResult = jobMgr->CreateJob(cleanJobs);
+        if (!jobResult) {
+            LogPrintf("Stratum: failed to create job: %s\n",
+                      util::ErrorString(jobResult).original);
+            return;
+        }
+        jobMgr->PruneJobs(m_config.jobCacheSize);
+        BroadcastJob(*jobResult);
+    }
+}
+
+void StratumServer::PeriodicMaintenance() {
+    LOCK(m_cs);
+    int64_t now = GetTime();
+
+    // Clean up timed-out workers
+    std::vector<uint32_t> toRemove;
+    for (auto &[id, session] : m_sessions) {
+        if (session->worker->IsTimedOut(m_config.workerTimeoutSec, now)) {
+            toRemove.push_back(id);
+            continue;
+        }
+
+        // Vardiff retarget
+        if (session->worker->ShouldRetargetDifficulty(m_config, now)) {
+            double newDiff = session->worker->CalcNewDifficulty(m_config, now);
+            if (std::abs(newDiff - session->worker->GetCurrentDifficulty()) /
+                    session->worker->GetCurrentDifficulty() >
+                m_config.varDiffVariance) {
+                session->worker->SetDifficulty(newDiff);
+                SendDifficulty(id, newDiff);
+            }
+        }
+    }
+
+    for (uint32_t id : toRemove) {
+        LogPrint(BCLog::STRATUM, "Stratum: timing out worker #%d\n", id);
+        auto it = m_sessions.find(id);
+        if (it != m_sessions.end()) {
+            if (it->second->bev) {
+                bufferevent_free(it->second->bev);
+                it->second->bev = nullptr;
+            }
+            m_sessions.erase(it);
+        }
+    }
+}
+
+// --- Global lifecycle ---
+
+bool InitStratumServer(const StratumConfig &config, Chainstate &chainstate,
+                       const CTxMemPool *mempool,
+                       const CChainParams &chainParams,
+                       ChainstateManager &chainman) {
+    g_stratumServer = std::make_unique<StratumServer>(
+        config, chainstate, mempool, chainParams, chainman);
+    return true;
+}
+
+void StartStratumServer() {
+    if (g_stratumServer) {
+        if (!g_stratumServer->Start()) {
+            LogPrintf("Stratum: failed to start server\n");
+            g_stratumServer.reset();
+        }
+    }
+}
+
+void InterruptStratumServer() {
+    if (g_stratumServer) {
+        g_stratumServer->Interrupt();
+    }
+}
+
+void StopStratumServer() {
+    if (g_stratumServer) {
+        g_stratumServer->Stop();
+        g_stratumServer.reset();
+    }
+}
+
+} // namespace stratum

--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -21,9 +21,7 @@
 #include <event2/listener.h>
 #include <event2/thread.h>
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
+#include <compat.h>
 
 namespace stratum {
 
@@ -81,7 +79,11 @@ bool StratumServer::Start() {
 
     // Thread-safety: BroadcastJob/BroadcastRawNotify are called from the
     // validation thread while the event loop runs on m_eventThread.
+#ifdef WIN32
+    evthread_use_windows_threads();
+#else
     evthread_use_pthreads();
+#endif
 
     m_eventBase = event_base_new();
     if (!m_eventBase) {
@@ -403,6 +405,7 @@ void StratumServer::HandleAuthorize(ClientSession &session,
 
 void StratumServer::HandleSubmit(ClientSession &session,
                                   const StratumRequest &req) {
+    AssertLockHeld(m_cs);
     if (session.worker->GetState() != StratumWorker::State::AUTHORIZED) {
         UniValue err(UniValue::VARR);
         err.push_back(StratumError::UNAUTHORIZED);

--- a/src/stratum/stratum.h
+++ b/src/stratum/stratum.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUM_H
+#define BITCOIN_STRATUM_STRATUM_H
+
+#include <stratum/stratumaux.h>
+#include <stratum/stratumconfig.h>
+#include <stratum/stratumjob.h>
+#include <stratum/stratumprotocol.h>
+#include <stratum/stratumrouter.h>
+#include <stratum/stratumstats.h>
+#include <stratum/stratumsubmit.h>
+#include <stratum/stratumworker.h>
+#include <validationinterface.h>
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <thread>
+
+struct event_base;
+struct evconnlistener;
+struct bufferevent;
+
+class CBlockIndex;
+class CChainParams;
+class Chainstate;
+class ChainstateManager;
+class CTxMemPool;
+
+namespace stratum {
+
+/**
+ * The main Stratum mining server.
+ *
+ * Listens for TCP connections from miners, manages subscriptions, creates
+ * block templates, distributes work via mining.notify, validates submitted
+ * shares (Scrypt PoW), and submits found blocks.
+ *
+ * Lifecycle follows the same pattern as httpserver:
+ *   InitStratumServer → StartStratumServer → InterruptStratumServer →
+ *   StopStratumServer
+ */
+class StratumServer final : public CValidationInterface {
+public:
+    StratumServer(const StratumConfig &config, Chainstate &chainstate,
+                  const CTxMemPool *mempool, const CChainParams &chainParams,
+                  ChainstateManager &chainman);
+    ~StratumServer();
+
+    bool Start();
+    void Interrupt();
+    void Stop();
+
+    /** Broadcast a new job to all authorized workers. */
+    void BroadcastJob(const StratumJob &job);
+
+    /** Send mining.set_difficulty to a specific worker. */
+    void SendDifficulty(uint32_t sessionId, double difficulty);
+
+    /** Get a snapshot of server stats. */
+    StratumServerStats GetStats() const;
+
+    size_t GetWorkerCount() const;
+
+protected:
+    // CValidationInterface: called when the active chain tip changes
+    void UpdatedBlockTip(const CBlockIndex *pindexNew,
+                         const CBlockIndex *pindexFork,
+                         bool fInitialDownload) override;
+
+private:
+    struct ClientSession {
+        uint32_t sessionId;
+        std::unique_ptr<StratumWorker> worker;
+        StratumLineBuffer lineBuffer;
+        struct bufferevent *bev = nullptr;
+        std::set<std::string> submittedNonces;
+    };
+
+    StratumConfig m_config;
+    Chainstate &m_chainstate;
+    const CChainParams &m_chainParams;
+    ChainstateManager &m_chainman;
+
+    std::unique_ptr<StratumRouter> m_router;
+    std::unique_ptr<StratumAuxManager> m_auxMgr;
+    ExtranonceMgr m_extranonceMgr;
+
+    struct event_base *m_eventBase = nullptr;
+    struct evconnlistener *m_listener = nullptr;
+    std::thread m_eventThread;
+    std::atomic<bool> m_running{false};
+    std::atomic<bool> m_interrupt{false};
+
+    mutable RecursiveMutex m_cs;
+    std::map<uint32_t, std::unique_ptr<ClientSession>> m_sessions
+        GUARDED_BY(m_cs);
+    uint32_t m_nextSessionId GUARDED_BY(m_cs) = 1;
+
+    // Stats
+    std::atomic<uint64_t> m_totalConnections{0};
+    std::atomic<uint64_t> m_totalSharesAccepted{0};
+    std::atomic<uint64_t> m_totalSharesRejected{0};
+    std::atomic<uint64_t> m_totalSharesStale{0};
+    std::atomic<uint64_t> m_blocksFound{0};
+    int64_t m_startTime = 0;
+
+    // libevent callbacks (static, forwarded to instance methods)
+    static void OnAccept(struct evconnlistener *listener, int fd,
+                         struct sockaddr *addr, int socklen, void *ctx);
+    static void OnRead(struct bufferevent *bev, void *ctx);
+    static void OnEvent(struct bufferevent *bev, short events, void *ctx);
+
+    void HandleAccept(int fd, struct sockaddr *addr);
+    void HandleRead(uint32_t sessionId);
+    void HandleDisconnect(uint32_t sessionId);
+
+    void ProcessMessage(ClientSession &session, const StratumMessage &msg);
+    void HandleSubscribe(ClientSession &session, const StratumRequest &req);
+    void HandleAuthorize(ClientSession &session, const StratumRequest &req);
+    void HandleSubmit(ClientSession &session, const StratumRequest &req);
+
+    void SendToClient(ClientSession &session, const std::string &data);
+    void SendResponse(ClientSession &session, int64_t id,
+                      const UniValue &result, const UniValue &error);
+
+    void CreateAndBroadcastJob(bool cleanJobs);
+    void PeriodicMaintenance();
+
+    // Router-driven broadcast helpers (called from router callbacks)
+    void BroadcastRawNotify(const std::string &rawLine);
+    void BroadcastDifficultyAll(double difficulty);
+    void HandleProxySubmitResult(int64_t minerId, bool accepted,
+                                 const std::string &error);
+
+    // Pending proxy submit mappings: request_id → session_id
+    std::map<int64_t, uint32_t> m_pendingProxySubmits GUARDED_BY(m_cs);
+
+    void EventLoop();
+};
+
+// Global lifecycle functions (called from init.cpp)
+bool InitStratumServer(const StratumConfig &config, Chainstate &chainstate,
+                       const CTxMemPool *mempool,
+                       const CChainParams &chainParams,
+                       ChainstateManager &chainman);
+void StartStratumServer();
+void InterruptStratumServer();
+void StopStratumServer();
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUM_H

--- a/src/stratum/stratumconfig.cpp
+++ b/src/stratum/stratumconfig.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumconfig.h>
+
+#include <common/args.h>
+#include <tinyformat.h>
+#include <util/translation.h>
+
+#include <cstdlib>
+
+namespace stratum {
+
+void RegisterStratumArgs(ArgsManager &args) {
+    args.AddArg("-stratum",
+                "Enable the built-in Stratum mining server (default: 0)",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumbind=<addr>",
+                "Bind Stratum server to this address (default: 0.0.0.0)",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg(
+        "-stratumport=<port>",
+        strprintf("Listen for Stratum connections on <port> (default: %u)",
+                  DEFAULT_STRATUM_PORT),
+        ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg(
+        "-stratumdifficulty=<n>",
+        strprintf("Initial share difficulty for Stratum workers (default: %g)",
+                  DEFAULT_STRATUM_DIFFICULTY),
+        ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumvardiff",
+                "Enable variable difficulty for Stratum workers (default: 1)",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg(
+        "-stratumvardifftarget=<n>",
+        strprintf("Target seconds between shares for vardiff (default: %g)",
+                  DEFAULT_VARDIFF_TARGET_TIME),
+        ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg(
+        "-stratumvardiffretarget=<n>",
+        strprintf("Seconds between vardiff retarget checks (default: %g)",
+                  DEFAULT_VARDIFF_RETARGET_TIME),
+        ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratummaxworkers=<n>",
+                strprintf("Maximum concurrent Stratum workers (default: %d)",
+                          DEFAULT_MAX_WORKERS),
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg(
+        "-stratumworkertimeout=<n>",
+        strprintf("Worker idle timeout in seconds (default: %d)",
+                  DEFAULT_WORKER_TIMEOUT_SEC),
+        ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumcoinbase=<address>",
+                "Dogecoin address for Stratum coinbase payouts",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumproxy=<spec>",
+                "Add an upstream pool for proxy/failover routing. Format: "
+                "host:port:user[:pass[:priority]]. Can be specified multiple "
+                "times. Lower priority = preferred. (default: none)",
+                ArgsManager::ALLOW_ANY,
+                OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumpreferlocal",
+                "Prefer local node mining when synced over proxy "
+                "(default: 1). Set to 0 to always prefer upstream pools.",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    args.AddArg("-stratumwarnsolo",
+                "Log a warning when solo-mining locally with no upstream "
+                "pool available (default: 1)",
+                ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+}
+
+util::Result<StratumConfig> ParseStratumConfig(const ArgsManager &args) {
+    StratumConfig config;
+
+    config.enabled = args.GetBoolArg("-stratum", false);
+    if (!config.enabled) {
+        return config;
+    }
+
+    config.bind = args.GetArg("-stratumbind", "0.0.0.0");
+
+    int64_t port = args.GetIntArg("-stratumport", DEFAULT_STRATUM_PORT);
+    if (port < 1 || port > 65535) {
+        return {{_("Stratum port out of range (1-65535)")}};
+    }
+    config.port = static_cast<uint16_t>(port);
+
+    config.defaultDifficulty = atof(
+        args.GetArg("-stratumdifficulty",
+                    strprintf("%g", DEFAULT_STRATUM_DIFFICULTY)).c_str());
+    if (config.defaultDifficulty < MIN_DIFFICULTY) {
+        return {{strprintf(
+            Untranslated("Stratum difficulty too low (minimum %g)"),
+            MIN_DIFFICULTY)}};
+    }
+    if (config.defaultDifficulty > MAX_DIFFICULTY) {
+        return {{strprintf(
+            Untranslated("Stratum difficulty too high (maximum %g)"),
+            MAX_DIFFICULTY)}};
+    }
+
+    config.useVarDiff = args.GetBoolArg("-stratumvardiff", DEFAULT_STRATUM_VARDIFF);
+
+    config.varDiffTargetTime = atof(
+        args.GetArg("-stratumvardifftarget",
+                    strprintf("%g", DEFAULT_VARDIFF_TARGET_TIME)).c_str());
+    if (config.varDiffTargetTime <= 0) {
+        return {{_("Stratum vardiff target time must be positive")}};
+    }
+
+    config.varDiffRetargetTime = atof(
+        args.GetArg("-stratumvardiffretarget",
+                    strprintf("%g", DEFAULT_VARDIFF_RETARGET_TIME)).c_str());
+    if (config.varDiffRetargetTime <= 0) {
+        return {{_("Stratum vardiff retarget time must be positive")}};
+    }
+
+    int64_t maxWorkers =
+        args.GetIntArg("-stratummaxworkers", DEFAULT_MAX_WORKERS);
+    if (maxWorkers < 1) {
+        return {{_("Stratum max workers must be at least 1")}};
+    }
+    config.maxWorkers = static_cast<int>(maxWorkers);
+
+    int64_t timeout =
+        args.GetIntArg("-stratumworkertimeout", DEFAULT_WORKER_TIMEOUT_SEC);
+    if (timeout < 1) {
+        return {{_("Stratum worker timeout must be at least 1 second")}};
+    }
+    config.workerTimeoutSec = static_cast<int>(timeout);
+
+    config.coinbaseAddress = args.GetArg("-stratumcoinbase", "");
+
+    // Tiered routing options
+    config.preferLocal =
+        args.GetBoolArg("-stratumpreferlocal", true);
+    config.warnSoloMining =
+        args.GetBoolArg("-stratumwarnsolo", true);
+
+    // Parse upstream pool specs: host:port:user[:pass[:priority]]
+    for (const auto &spec : args.GetArgs("-stratumproxy")) {
+        StratumPoolEntry entry;
+        std::vector<std::string> parts;
+        std::string token;
+        for (char c : spec) {
+            if (c == ':' && parts.size() < 4) {
+                // Split on first 4 colons only (host:port:user:pass:priority)
+                // but host could be IPv4, so port delimiter is after first part
+                parts.push_back(token);
+                token.clear();
+            } else {
+                token += c;
+            }
+        }
+        parts.push_back(token);
+
+        if (parts.size() < 3) {
+            return {{strprintf(
+                Untranslated("-stratumproxy format: host:port:user[:pass[:priority]], got '%s'"),
+                spec)}};
+        }
+
+        entry.host = parts[0];
+        entry.port = static_cast<uint16_t>(atoi(parts[1].c_str()));
+        if (entry.port == 0) {
+            return {{strprintf(
+                Untranslated("Invalid port in -stratumproxy '%s'"), spec)}};
+        }
+        entry.username = parts[2];
+        if (parts.size() > 3 && !parts[3].empty()) {
+            entry.password = parts[3];
+        }
+        if (parts.size() > 4) {
+            entry.priority = atoi(parts[4].c_str());
+        } else {
+            // Auto-assign priority by order of appearance
+            entry.priority =
+                static_cast<int>(config.upstreamPools.size());
+        }
+
+        config.upstreamPools.push_back(entry);
+    }
+
+    return config;
+}
+
+} // namespace stratum

--- a/src/stratum/stratumconfig.h
+++ b/src/stratum/stratumconfig.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMCONFIG_H
+#define BITCOIN_STRATUM_STRATUMCONFIG_H
+
+#include <cstdint>
+#include <script/standard.h>
+#include <string>
+#include <util/result.h>
+#include <vector>
+
+class ArgsManager;
+
+namespace stratum {
+
+static constexpr uint16_t DEFAULT_STRATUM_PORT = 3333;
+static constexpr double DEFAULT_STRATUM_DIFFICULTY = 0.5;
+static constexpr bool DEFAULT_STRATUM_VARDIFF = true;
+static constexpr double DEFAULT_VARDIFF_TARGET_TIME = 15.0;
+static constexpr double DEFAULT_VARDIFF_RETARGET_TIME = 90.0;
+static constexpr double DEFAULT_VARDIFF_VARIANCE = 0.25;
+static constexpr int DEFAULT_MAX_WORKERS = 1024;
+static constexpr int DEFAULT_WORKER_TIMEOUT_SEC = 300;
+static constexpr size_t DEFAULT_JOB_CACHE_SIZE = 8;
+static constexpr double MIN_DIFFICULTY = 0.0000001;
+static constexpr double MAX_DIFFICULTY = 1e12;
+
+/**
+ * A remote upstream pool endpoint for proxy/failover routing.
+ * Parsed from -stratumproxy=host:port:user:pass:priority
+ */
+struct StratumPoolEntry {
+    std::string host;
+    uint16_t port = 3333;
+    std::string username;
+    std::string password = "x";
+    int priority = 0;
+};
+
+struct StratumConfig {
+    bool enabled = false;
+    std::string bind = "0.0.0.0";
+    uint16_t port = DEFAULT_STRATUM_PORT;
+    double defaultDifficulty = DEFAULT_STRATUM_DIFFICULTY;
+    bool useVarDiff = DEFAULT_STRATUM_VARDIFF;
+    double varDiffTargetTime = DEFAULT_VARDIFF_TARGET_TIME;
+    double varDiffRetargetTime = DEFAULT_VARDIFF_RETARGET_TIME;
+    double varDiffVariance = DEFAULT_VARDIFF_VARIANCE;
+    int maxWorkers = DEFAULT_MAX_WORKERS;
+    int workerTimeoutSec = DEFAULT_WORKER_TIMEOUT_SEC;
+    size_t jobCacheSize = DEFAULT_JOB_CACHE_SIZE;
+    std::string coinbaseAddress;
+
+    // Tiered routing
+    bool preferLocal = true;     // Use local node when synced (tier 1)
+    bool warnSoloMining = true;  // Warn when falling through to local-only
+    std::vector<StratumPoolEntry> upstreamPools; // Proxy targets (tier 2+)
+};
+
+void RegisterStratumArgs(ArgsManager &args);
+util::Result<StratumConfig> ParseStratumConfig(const ArgsManager &args);
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMCONFIG_H

--- a/src/stratum/stratumjob.cpp
+++ b/src/stratum/stratumjob.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumjob.h>
+
+#include <chainparams.h>
+#include <config.h>
+#include <consensus/merkle.h>
+#include <node/miner.h>
+#include <primitives/auxpow.h>
+#include <streams.h>
+#include <util/strencodings.h>
+#include <util/translation.h>
+#include <validation.h>
+
+namespace stratum {
+
+StratumJobManager::StratumJobManager(Chainstate &chainstate,
+                                     const CTxMemPool *mempool,
+                                     const CChainParams &params,
+                                     const CScript &coinbaseScript,
+                                     size_t extranonce1Size,
+                                     size_t extranonce2Size)
+    : m_chainstate(chainstate), m_mempool(mempool), m_params(params),
+      m_coinbaseScript(coinbaseScript), m_extranonce1Size(extranonce1Size),
+      m_extranonce2Size(extranonce2Size) {}
+
+std::pair<std::string, std::string>
+StratumJobManager::SplitCoinbase(const CTransaction &coinbaseTx) const {
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << coinbaseTx;
+    std::string fullHex = HexStr(ss);
+    std::vector<uint8_t> raw = ParseHex(fullHex);
+
+    // Tx layout: [version:4][vin_count:varint][prevout:36]
+    //            [scriptSig_len:varint][scriptSig:N][sequence:4]
+    //            [vout_count:varint][vouts...][locktime:4]
+    //
+    // The miner will insert extranonce1 + extranonce2 into the scriptSig,
+    // so we must update scriptSig_len to include those extra bytes.
+
+    size_t pos = 0;
+    pos += 4;  // version
+    pos += 1;  // vin count (always 1 for coinbase)
+    pos += 36; // prevout (32 hash + 4 index)
+
+    size_t scriptSigLenPos = pos;
+
+    // Read original scriptSig length (varint)
+    uint64_t origScriptSigLen = 0;
+    int varintBytes = 0;
+    if (raw[pos] < 0xfd) {
+        origScriptSigLen = raw[pos];
+        varintBytes = 1;
+    } else if (raw[pos] == 0xfd) {
+        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8);
+        varintBytes = 3;
+    } else {
+        origScriptSigLen = raw[pos + 1] | (raw[pos + 2] << 8) |
+                           (raw[pos + 3] << 16) |
+                           ((uint64_t)raw[pos + 4] << 24);
+        varintBytes = 5;
+    }
+    pos += varintBytes;
+
+    size_t scriptSigStart = pos;
+    size_t scriptSigEnd = pos + origScriptSigLen;
+
+    // New scriptSig length = original + extranonce1 + extranonce2
+    uint64_t extranonceSpace = m_extranonce1Size + m_extranonce2Size;
+    uint64_t newScriptSigLen = origScriptSigLen + extranonceSpace;
+
+    // Encode the new length as varint
+    std::vector<uint8_t> newVarint;
+    if (newScriptSigLen < 0xfd) {
+        newVarint.push_back((uint8_t)newScriptSigLen);
+    } else if (newScriptSigLen <= 0xffff) {
+        newVarint.push_back(0xfd);
+        newVarint.push_back(newScriptSigLen & 0xff);
+        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
+    } else {
+        newVarint.push_back(0xfe);
+        newVarint.push_back(newScriptSigLen & 0xff);
+        newVarint.push_back((newScriptSigLen >> 8) & 0xff);
+        newVarint.push_back((newScriptSigLen >> 16) & 0xff);
+        newVarint.push_back((newScriptSigLen >> 24) & 0xff);
+    }
+
+    // Rebuild: [prefix before scriptSig_len] + [new varint] + [scriptSig] =>
+    //          coinbase1 (miner appends extranonce1 + extranonce2 here)
+    // coinbase2 = [sequence] + [vout...] + [locktime]
+    std::vector<uint8_t> cb1Data;
+    cb1Data.insert(cb1Data.end(), raw.begin(),
+                   raw.begin() + scriptSigLenPos);
+    cb1Data.insert(cb1Data.end(), newVarint.begin(), newVarint.end());
+    cb1Data.insert(cb1Data.end(), raw.begin() + scriptSigStart,
+                   raw.begin() + scriptSigEnd);
+
+    std::vector<uint8_t> cb2Data(raw.begin() + scriptSigEnd, raw.end());
+
+    return {HexStr(cb1Data), HexStr(cb2Data)};
+}
+
+std::vector<uint256>
+StratumJobManager::ComputeMerkleBranches(const CBlock &block) const {
+    std::vector<uint256> branches;
+    std::vector<uint256> leaves;
+    for (const auto &tx : block.vtx) {
+        leaves.push_back(tx->GetHash());
+    }
+
+    if (leaves.size() <= 1) {
+        return branches;
+    }
+
+    // Standard merkle branch for leaf at index 0 (the coinbase)
+    std::vector<uint256> level = leaves;
+    size_t index = 0;
+    while (level.size() > 1) {
+        // Sibling of the current index
+        size_t siblingIdx = index ^ 1;
+        if (siblingIdx < level.size()) {
+            branches.push_back(level[siblingIdx]);
+        } else {
+            branches.push_back(level[index]);
+        }
+
+        // Next level
+        std::vector<uint256> nextLevel;
+        for (size_t i = 0; i < level.size(); i += 2) {
+            uint256 left = level[i];
+            uint256 right = (i + 1 < level.size()) ? level[i + 1] : left;
+            nextLevel.push_back(Hash(Span(left), Span(right)));
+        }
+        level = nextLevel;
+        index /= 2;
+    }
+
+    return branches;
+}
+
+util::Result<StratumJob> StratumJobManager::CreateJob(bool cleanJobs) {
+    LOCK(cs_main);
+
+    const CBlockIndex *pindexPrev = m_chainstate.m_chain.Tip();
+    if (!pindexPrev) {
+        return {{_("No chain tip available")}};
+    }
+
+    node::BlockAssembler assembler(
+        ::GetConfig(), m_chainstate, m_mempool);
+
+    auto blockTemplate = assembler.CreateNewBlock(m_coinbaseScript);
+    if (!blockTemplate) {
+        return {{_("Failed to create block template")}};
+    }
+
+    CBlock &block = blockTemplate->block;
+
+    StratumJob job;
+    job.jobId = m_nextJobId++;
+    job.block = std::make_shared<CBlock>(block);
+    job.blockTemplate = std::move(blockTemplate);
+    job.cleanJobs = cleanJobs;
+    job.nBitsRaw = block.nBits;
+    job.nVersionRaw = block.nVersion;
+    job.height = pindexPrev->nHeight + 1;
+
+    // Split coinbase
+    auto [cb1, cb2] = SplitCoinbase(*block.vtx[0]);
+    job.coinbase1 = cb1;
+    job.coinbase2 = cb2;
+
+    // Merkle branches
+    auto branches = ComputeMerkleBranches(block);
+    for (const auto &b : branches) {
+        job.merkleBranches.push_back(HexStr(Span(b)));
+    }
+
+    // Header fields in Stratum hex format
+    job.prevHash = HashToStratumHex(block.hashPrevBlock);
+    job.version = Uint32ToStratumHex(block.nVersion);
+    job.nbits = Uint32ToStratumHex(block.nBits);
+    job.ntime = Uint32ToStratumHex(block.nTime);
+
+    m_lastTipHash = pindexPrev->GetBlockHash();
+
+    uint64_t id = job.jobId;
+    m_jobs[id] = job;
+
+    return job;
+}
+
+UniValue StratumJobManager::FormatNotifyParams(const StratumJob &job) const {
+    UniValue params(UniValue::VARR);
+    params.push_back(strprintf("%x", job.jobId));
+    params.push_back(job.prevHash);
+    params.push_back(job.coinbase1);
+    params.push_back(job.coinbase2);
+
+    UniValue branches(UniValue::VARR);
+    for (const auto &b : job.merkleBranches) {
+        branches.push_back(b);
+    }
+    params.push_back(branches);
+
+    params.push_back(job.version);
+    params.push_back(job.nbits);
+    params.push_back(job.ntime);
+    params.push_back(job.cleanJobs);
+
+    return params;
+}
+
+const StratumJob *StratumJobManager::GetJob(uint64_t jobId) const {
+    auto it = m_jobs.find(jobId);
+    if (it == m_jobs.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+void StratumJobManager::PruneJobs(size_t keepCount) {
+    while (m_jobs.size() > keepCount) {
+        m_jobs.erase(m_jobs.begin());
+    }
+}
+
+bool StratumJobManager::HasNewTip() const {
+    LOCK(cs_main);
+    const CBlockIndex *tip = m_chainstate.m_chain.Tip();
+    if (!tip) {
+        return false;
+    }
+    return tip->GetBlockHash() != m_lastTipHash;
+}
+
+size_t StratumJobManager::JobCount() const {
+    return m_jobs.size();
+}
+
+std::string HashToStratumHex(const uint256 &hash) {
+    // Stratum prevhash: 32 bytes, each 4-byte word byte-swapped
+    const uint8_t *data = hash.begin();
+    std::string result;
+    result.reserve(64);
+    for (int i = 0; i < 32; i += 4) {
+        for (int j = 3; j >= 0; j--) {
+            result += strprintf("%02x", data[i + j]);
+        }
+    }
+    return result;
+}
+
+std::string Uint32ToStratumHex(uint32_t val) {
+    uint8_t buf[4];
+    buf[0] = val & 0xff;
+    buf[1] = (val >> 8) & 0xff;
+    buf[2] = (val >> 16) & 0xff;
+    buf[3] = (val >> 24) & 0xff;
+    return HexStr(Span<const uint8_t>(buf, 4));
+}
+
+} // namespace stratum

--- a/src/stratum/stratumjob.h
+++ b/src/stratum/stratumjob.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMJOB_H
+#define BITCOIN_STRATUM_STRATUMJOB_H
+
+#include <primitives/block.h>
+#include <script/script.h>
+#include <univalue.h>
+#include <util/result.h>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+class CChainParams;
+class Chainstate;
+class CTxMemPool;
+
+namespace node {
+struct CBlockTemplate;
+}
+
+namespace stratum {
+
+struct StratumJob {
+    uint64_t jobId;
+    std::shared_ptr<CBlock> block;
+    std::shared_ptr<node::CBlockTemplate> blockTemplate;
+    std::string coinbase1; // hex: serialized coinbase up to extranonce
+    std::string coinbase2; // hex: serialized coinbase after extranonce
+    std::vector<std::string> merkleBranches; // hex hashes
+    std::string prevHash;                    // hex, 32 bytes reversed
+    std::string version;                     // hex, 4 bytes
+    std::string nbits;                       // hex, 4 bytes
+    std::string ntime;                       // hex, 4 bytes
+    bool cleanJobs = false;
+    uint32_t nBitsRaw = 0;
+    int32_t nVersionRaw = 0;
+    int height = 0;
+};
+
+class StratumJobManager {
+public:
+    StratumJobManager(Chainstate &chainstate, const CTxMemPool *mempool,
+                      const CChainParams &params,
+                      const CScript &coinbaseScript,
+                      size_t extranonce1Size, size_t extranonce2Size);
+
+    /**
+     * Create a new job from the current chain tip.
+     * Calls BlockAssembler::CreateNewBlock internally.
+     */
+    util::Result<StratumJob> CreateJob(bool cleanJobs);
+
+    /** Format mining.notify params for a job. */
+    UniValue FormatNotifyParams(const StratumJob &job) const;
+
+    /** Retrieve a cached job by ID. */
+    const StratumJob *GetJob(uint64_t jobId) const;
+
+    /** Remove old jobs, keeping the most recent keepCount. */
+    void PruneJobs(size_t keepCount);
+
+    /** Check if the chain tip changed since last job creation. */
+    bool HasNewTip() const;
+
+    size_t JobCount() const;
+
+private:
+    Chainstate &m_chainstate;
+    const CTxMemPool *m_mempool;
+    const CChainParams &m_params;
+    CScript m_coinbaseScript;
+    size_t m_extranonce1Size;
+    size_t m_extranonce2Size;
+    uint64_t m_nextJobId = 1;
+    std::map<uint64_t, StratumJob> m_jobs;
+    BlockHash m_lastTipHash;
+
+    std::pair<std::string, std::string>
+    SplitCoinbase(const CTransaction &coinbaseTx) const;
+
+    std::vector<uint256> ComputeMerkleBranches(const CBlock &block) const;
+};
+
+/**
+ * Convert a 256-bit hash to the byte-swapped hex format Stratum uses for
+ * prevhash (groups of 4 bytes reversed within each 4-byte word).
+ */
+std::string HashToStratumHex(const uint256 &hash);
+
+/** Encode a uint32 as 8-char little-endian hex. */
+std::string Uint32ToStratumHex(uint32_t val);
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMJOB_H

--- a/src/stratum/stratumprotocol.cpp
+++ b/src/stratum/stratumprotocol.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumprotocol.h>
+
+#include <util/translation.h>
+
+namespace stratum {
+
+void StratumLineBuffer::Append(const char *data, size_t len) {
+    if (m_overflow) {
+        return;
+    }
+    m_buffer.append(data, len);
+    if (m_buffer.size() > MAX_LINE_LENGTH * 2) {
+        m_overflow = true;
+        m_buffer.clear();
+    }
+}
+
+std::vector<std::string> StratumLineBuffer::ExtractLines() {
+    std::vector<std::string> lines;
+    size_t pos = 0;
+    while (true) {
+        size_t newline = m_buffer.find('\n', pos);
+        if (newline == std::string::npos) {
+            break;
+        }
+        std::string line = m_buffer.substr(pos, newline - pos);
+        // Strip trailing \r
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        // Only yield non-empty lines
+        if (!line.empty()) {
+            if (line.size() > MAX_LINE_LENGTH) {
+                m_overflow = true;
+                m_buffer.clear();
+                return lines;
+            }
+            lines.push_back(std::move(line));
+        }
+        pos = newline + 1;
+    }
+    if (pos > 0) {
+        m_buffer.erase(0, pos);
+    }
+    return lines;
+}
+
+void StratumLineBuffer::Clear() {
+    m_buffer.clear();
+    m_overflow = false;
+}
+
+util::Result<StratumMessage> ParseStratumLine(const std::string &line) {
+    UniValue val;
+    if (!val.read(line)) {
+        return {{_("Invalid JSON")}};
+    }
+    if (!val.isObject()) {
+        return {{_("Stratum message must be a JSON object")}};
+    }
+
+    bool hasId = val.exists("id") && !val["id"].isNull();
+    bool hasMethod = val.exists("method");
+    bool hasResult = val.exists("result");
+    bool hasError = val.exists("error");
+
+    if (hasMethod && hasId) {
+        // Request: has id + method
+        StratumRequest req;
+        req.id = val["id"].getInt<int64_t>();
+        req.method = val["method"].get_str();
+        req.params = val.exists("params") ? val["params"] : UniValue(UniValue::VARR);
+        return StratumMessage{req};
+    }
+
+    if (hasMethod && !hasId) {
+        // Notification: has method, no id (or null id)
+        StratumNotification notif;
+        notif.method = val["method"].get_str();
+        notif.params =
+            val.exists("params") ? val["params"] : UniValue(UniValue::VARR);
+        return StratumMessage{notif};
+    }
+
+    if (hasId && (hasResult || hasError)) {
+        // Response: has id + result/error
+        StratumResponse resp;
+        resp.id = val["id"].getInt<int64_t>();
+        resp.result =
+            val.exists("result") ? val["result"] : UniValue(UniValue::VNULL);
+        resp.error =
+            val.exists("error") ? val["error"] : UniValue(UniValue::VNULL);
+        return StratumMessage{resp};
+    }
+
+    return {{_("Cannot determine Stratum message type")}};
+}
+
+std::string SerializeNotify(const std::string &method, const UniValue &params) {
+    UniValue msg(UniValue::VOBJ);
+    msg.pushKV("id", UniValue(UniValue::VNULL));
+    msg.pushKV("method", method);
+    msg.pushKV("params", params);
+    return msg.write() + "\n";
+}
+
+std::string SerializeResponse(int64_t id, const UniValue &result,
+                              const UniValue &error) {
+    UniValue msg(UniValue::VOBJ);
+    msg.pushKV("id", id);
+    msg.pushKV("result", result);
+    msg.pushKV("error", error);
+    return msg.write() + "\n";
+}
+
+std::string SerializeRequest(int64_t id, const std::string &method,
+                             const UniValue &params) {
+    UniValue msg(UniValue::VOBJ);
+    msg.pushKV("id", id);
+    msg.pushKV("method", method);
+    msg.pushKV("params", params);
+    return msg.write() + "\n";
+}
+
+} // namespace stratum

--- a/src/stratum/stratumprotocol.h
+++ b/src/stratum/stratumprotocol.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMPROTOCOL_H
+#define BITCOIN_STRATUM_STRATUMPROTOCOL_H
+
+#include <cstddef>
+#include <string>
+#include <univalue.h>
+#include <util/result.h>
+#include <variant>
+#include <vector>
+
+namespace stratum {
+
+static constexpr size_t MAX_LINE_LENGTH = 16384;
+
+struct StratumRequest {
+    int64_t id;
+    std::string method;
+    UniValue params;
+};
+
+struct StratumResponse {
+    int64_t id;
+    UniValue result;
+    UniValue error;
+};
+
+struct StratumNotification {
+    std::string method;
+    UniValue params;
+};
+
+using StratumMessage =
+    std::variant<StratumRequest, StratumResponse, StratumNotification>;
+
+/**
+ * Accumulates raw TCP bytes and extracts complete newline-delimited lines.
+ * Handles partial reads, multiple messages per chunk, and CR/LF variations.
+ */
+class StratumLineBuffer {
+public:
+    void Append(const char *data, size_t len);
+    std::vector<std::string> ExtractLines();
+    void Clear();
+    size_t Size() const { return m_buffer.size(); }
+    bool OverflowDetected() const { return m_overflow; }
+
+private:
+    std::string m_buffer;
+    bool m_overflow = false;
+};
+
+util::Result<StratumMessage> ParseStratumLine(const std::string &line);
+std::string SerializeNotify(const std::string &method, const UniValue &params);
+std::string SerializeResponse(int64_t id, const UniValue &result,
+                              const UniValue &error);
+std::string SerializeRequest(int64_t id, const std::string &method,
+                             const UniValue &params);
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMPROTOCOL_H

--- a/src/stratum/stratumstats.cpp
+++ b/src/stratum/stratumstats.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumstats.h>
+
+#include <util/time.h>
+
+namespace stratum {
+
+static StatsProvider g_statsProvider;
+
+UniValue FormatStatsJson(const StratumServerStats &stats) {
+    UniValue obj(UniValue::VOBJ);
+
+    int64_t now = GetTime();
+    obj.pushKV("uptime", now - stats.startTime);
+    obj.pushKV("totalConnections", stats.totalConnections);
+    obj.pushKV("activeWorkers", stats.activeWorkers);
+    obj.pushKV("totalSharesAccepted", stats.totalSharesAccepted);
+    obj.pushKV("totalSharesRejected", stats.totalSharesRejected);
+    obj.pushKV("totalSharesStale", stats.totalSharesStale);
+    obj.pushKV("blocksFound", stats.blocksFound);
+    obj.pushKV("networkDifficulty", stats.networkDifficulty);
+    obj.pushKV("chainHeight", stats.chainHeight);
+
+    UniValue workersArr(UniValue::VARR);
+    for (const auto &w : stats.workers) {
+        UniValue wObj(UniValue::VOBJ);
+        wObj.pushKV("name", w.workerName);
+        wObj.pushKV("difficulty", w.currentDifficulty);
+        wObj.pushKV("accepted", w.sharesAccepted);
+        wObj.pushKV("rejected", w.sharesRejected);
+        wObj.pushKV("stale", w.sharesStale);
+        wObj.pushKV("hashrate", w.estimatedHashrate);
+        wObj.pushKV("lastShareTime", w.lastShareTime);
+
+        std::string stateStr;
+        switch (w.state) {
+            case StratumWorker::State::CONNECTED:
+                stateStr = "connected";
+                break;
+            case StratumWorker::State::SUBSCRIBED:
+                stateStr = "subscribed";
+                break;
+            case StratumWorker::State::AUTHORIZED:
+                stateStr = "authorized";
+                break;
+            case StratumWorker::State::MINING:
+                stateStr = "mining";
+                break;
+        }
+        wObj.pushKV("state", stateStr);
+        workersArr.push_back(wObj);
+    }
+    obj.pushKV("workers", workersArr);
+
+    // Routing info
+    obj.pushKV("activeTier", stats.activeTier);
+    obj.pushKV("activeProxyIndex", stats.activeProxyIndex);
+
+    UniValue poolsArr(UniValue::VARR);
+    for (const auto &p : stats.upstreamPools) {
+        UniValue pObj(UniValue::VOBJ);
+        pObj.pushKV("label", p.label);
+        pObj.pushKV("connected", p.connected);
+        pObj.pushKV("healthy", p.healthy);
+        pObj.pushKV("priority", p.priority);
+        pObj.pushKV("consecutiveErrors", p.consecutiveErrors);
+        pObj.pushKV("lastError", p.lastError);
+        poolsArr.push_back(pObj);
+    }
+    obj.pushKV("upstreamPools", poolsArr);
+
+    return obj;
+}
+
+static bool StratumStatusHandler(Config &config, HTTPRequest *req,
+                                  const std::string &) {
+    if (!g_statsProvider) {
+        req->WriteReply(503, "Stratum server not available");
+        return true;
+    }
+
+    StratumServerStats stats = g_statsProvider();
+    UniValue json = FormatStatsJson(stats);
+
+    req->WriteHeader("Content-Type", "application/json");
+    req->WriteReply(200, json.write(2) + "\n");
+    return true;
+}
+
+void RegisterStratumHTTPHandlers(StatsProvider provider) {
+    g_statsProvider = std::move(provider);
+    RegisterHTTPHandler("/stratum/status", true, StratumStatusHandler);
+}
+
+void UnregisterStratumHTTPHandlers() {
+    UnregisterHTTPHandler("/stratum/status", true);
+    g_statsProvider = nullptr;
+}
+
+} // namespace stratum

--- a/src/stratum/stratumstats.h
+++ b/src/stratum/stratumstats.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMSTATS_H
+#define BITCOIN_STRATUM_STRATUMSTATS_H
+
+#include <httpserver.h>
+#include <stratum/stratumworker.h>
+#include <univalue.h>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+class Config;
+
+namespace stratum {
+
+struct UpstreamPoolStats {
+    std::string label;
+    bool connected = false;
+    bool healthy = false;
+    int priority = 0;
+    int consecutiveErrors = 0;
+    std::string lastError;
+};
+
+struct StratumServerStats {
+    int64_t startTime = 0;
+    uint64_t totalConnections = 0;
+    uint32_t activeWorkers = 0;
+    uint64_t totalSharesAccepted = 0;
+    uint64_t totalSharesRejected = 0;
+    uint64_t totalSharesStale = 0;
+    uint64_t blocksFound = 0;
+    double networkDifficulty = 0;
+    int chainHeight = 0;
+    std::vector<StratumWorker::Stats> workers;
+
+    // Routing info
+    std::string activeTier;
+    int activeProxyIndex = -1;
+    std::vector<UpstreamPoolStats> upstreamPools;
+};
+
+/**
+ * Callback type: the stratum server provides a function that returns current
+ * stats when called.
+ */
+using StatsProvider = std::function<StratumServerStats()>;
+
+/** Format stats as JSON for the HTTP endpoint. */
+UniValue FormatStatsJson(const StratumServerStats &stats);
+
+/** Register /stratum/status HTTP handler. */
+void RegisterStratumHTTPHandlers(StatsProvider provider);
+
+/** Unregister /stratum/status HTTP handler. */
+void UnregisterStratumHTTPHandlers();
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMSTATS_H

--- a/src/stratum/stratumsubmit.cpp
+++ b/src/stratum/stratumsubmit.cpp
@@ -1,0 +1,205 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumsubmit.h>
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <consensus/merkle.h>
+#include <crypto/scrypt.h>
+#include <hash.h>
+#include <pow/pow.h>
+#include <streams.h>
+#include <util/strencodings.h>
+#include <util/translation.h>
+#include <validation.h>
+
+namespace stratum {
+
+util::Result<ShareSubmission> ParseSubmitParams(const UniValue &params) {
+    if (!params.isArray() || params.size() < 5) {
+        return {{_("mining.submit requires 5 parameters")}};
+    }
+
+    ShareSubmission sub;
+    sub.workerName = params[0].get_str();
+
+    // Job ID is sent as hex string
+    std::string jobIdStr = params[1].get_str();
+    try {
+        sub.jobId = std::stoull(jobIdStr, nullptr, 16);
+    } catch (...) {
+        return {{_("Invalid job ID")}};
+    }
+
+    sub.extranonce2 = params[2].get_str();
+    sub.ntime = params[3].get_str();
+    sub.nonce = params[4].get_str();
+
+    // Validate hex formats
+    if (!IsHex(sub.extranonce2) || sub.extranonce2.size() != 8) {
+        return {{_("Invalid extranonce2 (expected 8 hex chars)")}};
+    }
+    if (!IsHex(sub.ntime) || sub.ntime.size() != 8) {
+        return {{_("Invalid ntime (expected 8 hex chars)")}};
+    }
+    if (!IsHex(sub.nonce) || sub.nonce.size() != 8) {
+        return {{_("Invalid nonce (expected 8 hex chars)")}};
+    }
+
+    return sub;
+}
+
+CBaseBlockHeader ReconstructHeader(const StratumJob &job,
+                                   const std::string &extranonce1,
+                                   const ShareSubmission &sub) {
+    // 1. Reconstruct the full coinbase transaction
+    std::string fullCoinbaseHex =
+        job.coinbase1 + extranonce1 + sub.extranonce2 + job.coinbase2;
+    std::vector<uint8_t> coinbaseBytes = ParseHex(fullCoinbaseHex);
+
+    CDataStream ss(coinbaseBytes, SER_NETWORK, PROTOCOL_VERSION);
+    CTransaction coinbaseTx(deserialize, ss);
+
+    // 2. Compute merkle root
+    uint256 coinbaseHash = coinbaseTx.GetHash();
+    uint256 merkleRoot = coinbaseHash;
+
+    // Apply merkle branches
+    for (const auto &branchHex : job.merkleBranches) {
+        uint256 branchHash;
+        branchHash.SetHex(branchHex);
+        merkleRoot = Hash(Span(merkleRoot), Span(branchHash));
+    }
+
+    // 3. Build header
+    CBaseBlockHeader header;
+    header.nVersion = job.nVersionRaw;
+    header.hashPrevBlock = job.block->hashPrevBlock;
+    header.hashMerkleRoot = merkleRoot;
+
+    // Parse ntime from submission (little-endian hex)
+    std::vector<uint8_t> ntimeBytes = ParseHex(sub.ntime);
+    header.nTime = ntimeBytes[0] | (ntimeBytes[1] << 8) |
+                   (ntimeBytes[2] << 16) | (ntimeBytes[3] << 24);
+
+    header.nBits = job.nBitsRaw;
+
+    // Parse nonce from submission (little-endian hex)
+    std::vector<uint8_t> nonceBytes = ParseHex(sub.nonce);
+    header.nNonce = nonceBytes[0] | (nonceBytes[1] << 8) |
+                    (nonceBytes[2] << 16) | (nonceBytes[3] << 24);
+
+    return header;
+}
+
+BlockHash ScryptPowHash(const CBaseBlockHeader &header) {
+    return header.GetPowHash();
+}
+
+arith_uint256 DifficultyToTarget(double difficulty) {
+    // Stratum difficulty 1 target for Scrypt:
+    // 0x0000ffff00000000000000000000000000000000000000000000000000000000
+    arith_uint256 target;
+    target.SetCompact(0x1d00ffff);
+
+    if (difficulty <= 0) {
+        return target;
+    }
+
+    // target = diff1_target / difficulty
+    // To avoid floating point, we use integer division with scaling.
+    // For reasonable precision, multiply then divide.
+    if (difficulty >= 1.0) {
+        // Integer path for difficulty >= 1
+        uint64_t diffInt = static_cast<uint64_t>(difficulty);
+        if (diffInt > 0 && static_cast<double>(diffInt) == difficulty) {
+            return target / diffInt;
+        }
+    }
+
+    // General floating point path
+    // target_new = target * (1/difficulty)
+    // Use 64-bit fixed point: multiply target by 1000000, divide by
+    // (difficulty * 1000000)
+    uint64_t scale = 1000000;
+    arith_uint256 scaled = target * scale;
+    uint64_t diffScaled = static_cast<uint64_t>(difficulty * scale);
+    if (diffScaled == 0) {
+        diffScaled = 1;
+    }
+    return scaled / diffScaled;
+}
+
+ShareResult ValidateShare(const StratumJob &job,
+                          const std::string &extranonce1,
+                          const ShareSubmission &sub,
+                          double workerDifficulty,
+                          const Consensus::Params &params,
+                          std::set<std::string> &submittedNonces) {
+    // Duplicate check: key = jobId + extranonce2 + nonce + ntime
+    std::string dupeKey = strprintf("%x:%s:%s:%s", sub.jobId, sub.extranonce2,
+                                    sub.nonce, sub.ntime);
+    if (submittedNonces.count(dupeKey)) {
+        return ShareResult::REJECTED_DUPLICATE;
+    }
+
+    CBaseBlockHeader header = ReconstructHeader(job, extranonce1, sub);
+    BlockHash powHash = ScryptPowHash(header);
+
+    arith_uint256 hashValue = UintToArith256(powHash);
+
+    // Check against network target (block found!)
+    arith_uint256 networkTarget;
+    if (!NBitsToTarget(params, job.nBitsRaw, networkTarget)) {
+        return ShareResult::REJECTED_INVALID;
+    }
+
+    submittedNonces.insert(dupeKey);
+
+    if (hashValue <= networkTarget) {
+        return ShareResult::ACCEPTED_BLOCK;
+    }
+
+    // Check against worker difficulty target (share)
+    arith_uint256 workerTarget = DifficultyToTarget(workerDifficulty);
+    if (hashValue <= workerTarget) {
+        return ShareResult::ACCEPTED;
+    }
+
+    return ShareResult::REJECTED_LOW_DIFF;
+}
+
+bool SubmitBlock(const StratumJob &job, const std::string &extranonce1,
+                 const ShareSubmission &sub, ChainstateManager &chainman,
+                 const CChainParams &chainParams) {
+    // Reconstruct the full coinbase
+    std::string fullCoinbaseHex =
+        job.coinbase1 + extranonce1 + sub.extranonce2 + job.coinbase2;
+    std::vector<uint8_t> coinbaseBytes = ParseHex(fullCoinbaseHex);
+
+    CDataStream ss(coinbaseBytes, SER_NETWORK, PROTOCOL_VERSION);
+    CMutableTransaction coinbaseMtx;
+    ss >> coinbaseMtx;
+
+    // Build the full block from the template
+    auto block = std::make_shared<CBlock>(*job.block);
+    block->vtx[0] = MakeTransactionRef(std::move(coinbaseMtx));
+    block->hashMerkleRoot = BlockMerkleRoot(*block);
+
+    // Set the nonce and ntime from submission
+    std::vector<uint8_t> ntimeBytes = ParseHex(sub.ntime);
+    block->nTime = ntimeBytes[0] | (ntimeBytes[1] << 8) |
+                   (ntimeBytes[2] << 16) | (ntimeBytes[3] << 24);
+
+    std::vector<uint8_t> nonceBytes = ParseHex(sub.nonce);
+    block->nNonce = nonceBytes[0] | (nonceBytes[1] << 8) |
+                    (nonceBytes[2] << 16) | (nonceBytes[3] << 24);
+
+    bool newBlock = false;
+    return chainman.ProcessNewBlock(block, /*force_processing=*/true,
+                                    /*min_pow_checked=*/true, &newBlock);
+}
+
+} // namespace stratum

--- a/src/stratum/stratumsubmit.h
+++ b/src/stratum/stratumsubmit.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMSUBMIT_H
+#define BITCOIN_STRATUM_STRATUMSUBMIT_H
+
+#include <arith_uint256.h>
+#include <consensus/params.h>
+#include <primitives/baseheader.h>
+#include <primitives/blockhash.h>
+#include <stratum/stratumjob.h>
+#include <univalue.h>
+#include <util/result.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+
+class ChainstateManager;
+
+namespace stratum {
+
+enum class ShareResult {
+    ACCEPTED,
+    ACCEPTED_BLOCK,
+    REJECTED_LOW_DIFF,
+    REJECTED_STALE,
+    REJECTED_DUPLICATE,
+    REJECTED_INVALID,
+};
+
+struct ShareSubmission {
+    std::string workerName;
+    uint64_t jobId;
+    std::string extranonce2; // hex
+    std::string ntime;       // hex, 4 bytes
+    std::string nonce;       // hex, 4 bytes
+};
+
+/** Parse mining.submit params into ShareSubmission. */
+util::Result<ShareSubmission> ParseSubmitParams(const UniValue &params);
+
+/**
+ * Reconstruct the complete coinbase transaction from coinbase1 + extranonce1 +
+ * extranonce2 + coinbase2, recompute the merkle root, and build the full
+ * 80-byte block header.
+ */
+CBaseBlockHeader ReconstructHeader(const StratumJob &job,
+                                   const std::string &extranonce1,
+                                   const ShareSubmission &sub);
+
+/** Compute Scrypt PoW hash of a block header. */
+BlockHash ScryptPowHash(const CBaseBlockHeader &header);
+
+/**
+ * Convert a Stratum difficulty value to a 256-bit target.
+ * Stratum difficulty 1 corresponds to target 0x00000000ffff... (pdiff).
+ */
+arith_uint256 DifficultyToTarget(double difficulty);
+
+/**
+ * Validate a submitted share:
+ * 1. Reconstruct header from job + extranonce1 + submission
+ * 2. Scrypt hash the header
+ * 3. Compare against worker difficulty target (share) and network target (block)
+ */
+ShareResult ValidateShare(const StratumJob &job,
+                          const std::string &extranonce1,
+                          const ShareSubmission &sub,
+                          double workerDifficulty,
+                          const Consensus::Params &params,
+                          std::set<std::string> &submittedNonces);
+
+/**
+ * Assemble the full CBlock from job + submission and call ProcessNewBlock.
+ */
+bool SubmitBlock(const StratumJob &job, const std::string &extranonce1,
+                 const ShareSubmission &sub, ChainstateManager &chainman,
+                 const CChainParams &chainParams);
+
+/** Stratum error codes per specification. */
+namespace StratumError {
+static constexpr int JOB_NOT_FOUND = 21;
+static constexpr int DUPLICATE_SHARE = 22;
+static constexpr int LOW_DIFFICULTY = 23;
+static constexpr int UNAUTHORIZED = 24;
+static constexpr int NOT_SUBSCRIBED = 25;
+} // namespace StratumError
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMSUBMIT_H

--- a/src/stratum/stratumworker.cpp
+++ b/src/stratum/stratumworker.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumworker.h>
+
+#include <util/strencodings.h>
+#include <util/time.h>
+#include <util/translation.h>
+
+#include <algorithm>
+#include <cmath>
+
+namespace stratum {
+
+StratumWorker::StratumWorker(uint32_t sessionId,
+                             const std::string &extranonce1,
+                             double initialDifficulty)
+    : m_state(State::CONNECTED), m_sessionId(sessionId),
+      m_extranonce1(extranonce1), m_difficulty(initialDifficulty) {
+    m_connectTime = GetTime();
+    m_lastActivityTime = m_connectTime;
+    m_lastRetargetTime = m_connectTime;
+}
+
+util::Result<UniValue> StratumWorker::HandleSubscribe(const UniValue &params) {
+    if (m_state != State::CONNECTED) {
+        return {{_("Already subscribed")}};
+    }
+
+    m_state = State::SUBSCRIBED;
+
+    // Build subscription response:
+    // [[["mining.set_difficulty","sub1"],["mining.notify","sub2"]], extranonce1,
+    // extranonce2_size]
+    UniValue subscriptions(UniValue::VARR);
+
+    UniValue diffSub(UniValue::VARR);
+    diffSub.push_back("mining.set_difficulty");
+    diffSub.push_back(HexStr(std::vector<uint8_t>(m_extranonce1.begin(),
+                                                   m_extranonce1.end()))
+                          .substr(0, 8));
+    subscriptions.push_back(diffSub);
+
+    UniValue notifySub(UniValue::VARR);
+    notifySub.push_back("mining.notify");
+    notifySub.push_back(HexStr(std::vector<uint8_t>(m_extranonce1.begin(),
+                                                     m_extranonce1.end()))
+                            .substr(0, 8));
+    subscriptions.push_back(notifySub);
+
+    UniValue result(UniValue::VARR);
+    result.push_back(subscriptions);
+    result.push_back(m_extranonce1);
+    result.push_back(static_cast<int>(EXTRANONCE2_SIZE));
+
+    return result;
+}
+
+util::Result<UniValue> StratumWorker::HandleAuthorize(const UniValue &params) {
+    if (m_state == State::CONNECTED) {
+        return {{_("Must subscribe before authorizing")}};
+    }
+    if (m_state == State::AUTHORIZED || m_state == State::MINING) {
+        return {{_("Already authorized")}};
+    }
+
+    if (!params.isArray() || params.size() < 1) {
+        return {{_("mining.authorize requires at least a username")}};
+    }
+
+    m_workerName = params[0].get_str();
+    m_state = State::AUTHORIZED;
+
+    return UniValue(true);
+}
+
+void StratumWorker::RecordShareAccepted(double difficulty) {
+    m_sharesAccepted++;
+    int64_t now = GetTime();
+    m_lastActivityTime = now;
+    m_shareTimestamps.push_back(now);
+
+    // Keep only last 100 timestamps for vardiff
+    if (m_shareTimestamps.size() > 100) {
+        m_shareTimestamps.erase(m_shareTimestamps.begin());
+    }
+}
+
+void StratumWorker::RecordShareRejected() {
+    m_sharesRejected++;
+    m_lastActivityTime = GetTime();
+}
+
+void StratumWorker::RecordShareStale() {
+    m_sharesStale++;
+    m_lastActivityTime = GetTime();
+}
+
+void StratumWorker::SetDifficulty(double diff) {
+    if (diff < MIN_DIFFICULTY) {
+        diff = MIN_DIFFICULTY;
+    }
+    if (diff > MAX_DIFFICULTY) {
+        diff = MAX_DIFFICULTY;
+    }
+    m_difficulty = diff;
+}
+
+bool StratumWorker::ShouldRetargetDifficulty(const StratumConfig &config,
+                                              int64_t now) const {
+    if (!config.useVarDiff) {
+        return false;
+    }
+    if (m_shareTimestamps.size() < 3) {
+        return false;
+    }
+    return (now - m_lastRetargetTime) >= (int64_t)config.varDiffRetargetTime;
+}
+
+double StratumWorker::CalcNewDifficulty(const StratumConfig &config,
+                                        int64_t now) const {
+    if (m_shareTimestamps.size() < 2) {
+        return m_difficulty;
+    }
+
+    // Average time between shares over the retarget window
+    int64_t windowStart = m_shareTimestamps.front();
+    int64_t windowEnd = m_shareTimestamps.back();
+    double elapsed = static_cast<double>(windowEnd - windowStart);
+    if (elapsed <= 0) {
+        return m_difficulty;
+    }
+
+    double avgShareTime = elapsed / (m_shareTimestamps.size() - 1);
+    double targetTime = config.varDiffTargetTime;
+
+    // Ratio: if shares come too fast, ratio > 1 → increase difficulty
+    double ratio = targetTime / avgShareTime;
+
+    // Dampen changes to avoid oscillation
+    double newDiff = m_difficulty * ratio;
+
+    // Enforce bounds
+    if (newDiff < MIN_DIFFICULTY) {
+        newDiff = MIN_DIFFICULTY;
+    }
+    if (newDiff > MAX_DIFFICULTY) {
+        newDiff = MAX_DIFFICULTY;
+    }
+
+    return newDiff;
+}
+
+StratumWorker::Stats StratumWorker::GetStats() const {
+    Stats s;
+    s.sharesAccepted = m_sharesAccepted;
+    s.sharesRejected = m_sharesRejected;
+    s.sharesStale = m_sharesStale;
+    s.currentDifficulty = m_difficulty;
+    s.lastShareTime = m_shareTimestamps.empty() ? 0 : m_shareTimestamps.back();
+    s.workerName = m_workerName;
+    s.state = m_state;
+
+    // Estimate hashrate from recent share rate: H/s ≈ (diff × 2^32) / time
+    if (m_sharesAccepted > 0 && m_shareTimestamps.size() >= 2) {
+        int64_t span = m_shareTimestamps.back() - m_shareTimestamps.front();
+        if (span > 0) {
+            double sharesPerSec =
+                static_cast<double>(m_shareTimestamps.size() - 1) / span;
+            s.estimatedHashrate =
+                sharesPerSec * m_difficulty * 4294967296.0; // 2^32
+        }
+    }
+
+    return s;
+}
+
+bool StratumWorker::IsTimedOut(int timeoutSec, int64_t now) const {
+    return (now - m_lastActivityTime) > timeoutSec;
+}
+
+void StratumWorker::Touch(int64_t now) {
+    m_lastActivityTime = now;
+}
+
+// --- ExtranonceMgr ---
+
+std::string ExtranonceMgr::Next() {
+    uint32_t val = m_counter.fetch_add(1);
+    // 4 bytes → 8 hex chars
+    uint8_t bytes[4];
+    bytes[0] = (val >> 24) & 0xff;
+    bytes[1] = (val >> 16) & 0xff;
+    bytes[2] = (val >> 8) & 0xff;
+    bytes[3] = val & 0xff;
+    return HexStr(Span<const uint8_t>(bytes, 4));
+}
+
+} // namespace stratum

--- a/src/stratum/stratumworker.h
+++ b/src/stratum/stratumworker.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRATUM_STRATUMWORKER_H
+#define BITCOIN_STRATUM_STRATUMWORKER_H
+
+#include <stratum/stratumconfig.h>
+#include <univalue.h>
+#include <util/result.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace stratum {
+
+class StratumWorker {
+public:
+    enum class State { CONNECTED, SUBSCRIBED, AUTHORIZED, MINING };
+
+    struct Stats {
+        uint64_t sharesAccepted = 0;
+        uint64_t sharesRejected = 0;
+        uint64_t sharesStale = 0;
+        double currentDifficulty = 0;
+        int64_t lastShareTime = 0;
+        double estimatedHashrate = 0;
+        std::string workerName;
+        State state = State::CONNECTED;
+    };
+
+    StratumWorker(uint32_t sessionId, const std::string &extranonce1,
+                  double initialDifficulty);
+
+    State GetState() const { return m_state; }
+    uint32_t GetSessionId() const { return m_sessionId; }
+    const std::string &GetExtranonce1() const { return m_extranonce1; }
+    const std::string &GetWorkerName() const { return m_workerName; }
+
+    /**
+     * Handle mining.subscribe — transitions CONNECTED → SUBSCRIBED.
+     * Returns [[[subscription_details], extranonce1, extranonce2_size]].
+     */
+    util::Result<UniValue> HandleSubscribe(const UniValue &params);
+
+    /**
+     * Handle mining.authorize — transitions SUBSCRIBED → AUTHORIZED.
+     * Returns true on success.
+     */
+    util::Result<UniValue> HandleAuthorize(const UniValue &params);
+
+    void RecordShareAccepted(double difficulty);
+    void RecordShareRejected();
+    void RecordShareStale();
+
+    double GetCurrentDifficulty() const { return m_difficulty; }
+    void SetDifficulty(double diff);
+
+    bool ShouldRetargetDifficulty(const StratumConfig &config,
+                                  int64_t now) const;
+    double CalcNewDifficulty(const StratumConfig &config, int64_t now) const;
+
+    Stats GetStats() const;
+    bool IsTimedOut(int timeoutSec, int64_t now) const;
+    void Touch(int64_t now);
+
+    static constexpr size_t EXTRANONCE2_SIZE = 4;
+
+private:
+    State m_state;
+    uint32_t m_sessionId;
+    std::string m_extranonce1;
+    std::string m_workerName;
+    double m_difficulty;
+    uint64_t m_sharesAccepted = 0;
+    uint64_t m_sharesRejected = 0;
+    uint64_t m_sharesStale = 0;
+    int64_t m_connectTime;
+    int64_t m_lastActivityTime;
+    int64_t m_lastRetargetTime;
+    std::vector<int64_t> m_shareTimestamps;
+};
+
+/**
+ * Generates unique extranonce1 values (4 bytes → 8 hex chars).
+ * Thread-safe via atomic counter.
+ */
+class ExtranonceMgr {
+public:
+    std::string Next();
+    void Reset() { m_counter.store(0); }
+
+private:
+    std::atomic<uint32_t> m_counter{0};
+};
+
+} // namespace stratum
+
+#endif // BITCOIN_STRATUM_STRATUMWORKER_H

--- a/src/stratum/test/CMakeLists.txt
+++ b/src/stratum/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+
+include(TestSuite)
+create_test_suite(stratum)
+add_dependencies(check check-stratum)
+
+add_boost_unit_tests_to_suite(stratum test_stratum
+	TESTS
+		stratumconfig_tests.cpp
+		stratumprotocol_tests.cpp
+		stratumworker_tests.cpp
+		stratumjob_tests.cpp
+		stratumsubmit_tests.cpp
+		stratumstats_tests.cpp
+)
+
+target_link_libraries(test_stratum server testutil)

--- a/src/stratum/test/stratumconfig_tests.cpp
+++ b/src/stratum/test/stratumconfig_tests.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumconfig.h>
+
+#include <common/args.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumconfig_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(parse_defaults) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK(!result->enabled);
+    BOOST_CHECK_EQUAL(result->port, DEFAULT_STRATUM_PORT);
+    BOOST_CHECK_EQUAL(result->bind, "0.0.0.0");
+    BOOST_CHECK_EQUAL(result->defaultDifficulty, DEFAULT_STRATUM_DIFFICULTY);
+    BOOST_CHECK_EQUAL(result->useVarDiff, DEFAULT_STRATUM_VARDIFF);
+    BOOST_CHECK_EQUAL(result->maxWorkers, DEFAULT_MAX_WORKERS);
+    BOOST_CHECK_EQUAL(result->workerTimeoutSec, DEFAULT_WORKER_TIMEOUT_SEC);
+}
+
+BOOST_AUTO_TEST_CASE(parse_enabled) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum"};
+    std::string error;
+    args.ParseParameters(2, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK(result->enabled);
+}
+
+BOOST_AUTO_TEST_CASE(parse_custom_port) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum", "-stratumport=9999"};
+    std::string error;
+    args.ParseParameters(3, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK_EQUAL(result->port, 9999);
+}
+
+BOOST_AUTO_TEST_CASE(parse_invalid_port) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum", "-stratumport=99999"};
+    std::string error;
+    args.ParseParameters(3, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(parse_bind_address) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum", "-stratumbind=127.0.0.1"};
+    std::string error;
+    args.ParseParameters(3, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK_EQUAL(result->bind, "127.0.0.1");
+}
+
+BOOST_AUTO_TEST_CASE(parse_max_workers_zero) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum", "-stratummaxworkers=0"};
+    std::string error;
+    args.ParseParameters(3, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(parse_worker_timeout_zero) {
+    ArgsManager args;
+    RegisterStratumArgs(args);
+
+    const char *argv[] = {"test", "-stratum", "-stratumworkertimeout=0"};
+    std::string error;
+    args.ParseParameters(3, argv, error);
+
+    auto result = ParseStratumConfig(args);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/stratum/test/stratumjob_tests.cpp
+++ b/src/stratum/test/stratumjob_tests.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumjob.h>
+
+#include <primitives/auxpow.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumjob_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(hash_to_stratum_hex_length) {
+    uint256 hash;
+    hash.SetNull();
+    std::string hex = HashToStratumHex(hash);
+    BOOST_CHECK_EQUAL(hex.size(), 64u);
+}
+
+BOOST_AUTO_TEST_CASE(uint32_to_stratum_hex_format) {
+    // 0x12345678 in little-endian hex = "78563412"
+    std::string hex = Uint32ToStratumHex(0x12345678);
+    BOOST_CHECK_EQUAL(hex, "78563412");
+}
+
+BOOST_AUTO_TEST_CASE(uint32_to_stratum_hex_zero) {
+    std::string hex = Uint32ToStratumHex(0);
+    BOOST_CHECK_EQUAL(hex, "00000000");
+}
+
+BOOST_AUTO_TEST_CASE(create_job_returns_valid) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto result = mgr.CreateJob(true);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK(result->jobId > 0);
+    BOOST_CHECK(!result->coinbase1.empty());
+    BOOST_CHECK(!result->coinbase2.empty());
+    BOOST_CHECK(!result->prevHash.empty());
+    BOOST_CHECK(!result->version.empty());
+    BOOST_CHECK(!result->nbits.empty());
+    BOOST_CHECK(!result->ntime.empty());
+    BOOST_CHECK(result->cleanJobs);
+}
+
+BOOST_AUTO_TEST_CASE(job_version_has_chain_id) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto result = mgr.CreateJob(true);
+    BOOST_REQUIRE(result.has_value());
+
+    // Chain ID should be 0x62 in bits 16-31
+    BOOST_CHECK_EQUAL(VersionChainId(result->nVersionRaw), AUXPOW_CHAIN_ID);
+}
+
+BOOST_AUTO_TEST_CASE(job_version_no_auxpow_flag) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto result = mgr.CreateJob(true);
+    BOOST_REQUIRE(result.has_value());
+
+    // Direct mining template should NOT have AuxPoW flag set
+    BOOST_CHECK(!VersionHasAuxPow(result->nVersionRaw));
+}
+
+BOOST_AUTO_TEST_CASE(notify_params_format) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto result = mgr.CreateJob(true);
+    BOOST_REQUIRE(result.has_value());
+
+    UniValue params = mgr.FormatNotifyParams(*result);
+    BOOST_CHECK(params.isArray());
+    BOOST_CHECK_EQUAL(params.size(), 9u);
+
+    // params[0] = jobId (string)
+    BOOST_CHECK(params[0].isStr());
+    // params[1] = prevHash (64 hex chars)
+    BOOST_CHECK_EQUAL(params[1].get_str().size(), 64u);
+    // params[4] = merkle branches (array)
+    BOOST_CHECK(params[4].isArray());
+    // params[5] = version (8 hex chars)
+    BOOST_CHECK_EQUAL(params[5].get_str().size(), 8u);
+    // params[6] = nbits (8 hex chars)
+    BOOST_CHECK_EQUAL(params[6].get_str().size(), 8u);
+    // params[7] = ntime (8 hex chars)
+    BOOST_CHECK_EQUAL(params[7].get_str().size(), 8u);
+    // params[8] = clean_jobs (bool)
+    BOOST_CHECK(params[8].isBool());
+}
+
+BOOST_AUTO_TEST_CASE(get_job_by_id) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto result = mgr.CreateJob(false);
+    BOOST_REQUIRE(result.has_value());
+
+    const StratumJob *found = mgr.GetJob(result->jobId);
+    BOOST_REQUIRE(found != nullptr);
+    BOOST_CHECK_EQUAL(found->jobId, result->jobId);
+}
+
+BOOST_AUTO_TEST_CASE(get_job_unknown_id) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    BOOST_CHECK(mgr.GetJob(99999) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(prune_jobs) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    for (int i = 0; i < 10; i++) {
+        mgr.CreateJob(false);
+    }
+    BOOST_CHECK_EQUAL(mgr.JobCount(), 10u);
+
+    mgr.PruneJobs(5);
+    BOOST_CHECK_EQUAL(mgr.JobCount(), 5u);
+}
+
+BOOST_AUTO_TEST_CASE(sequential_job_ids) {
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto r1 = mgr.CreateJob(false);
+    auto r2 = mgr.CreateJob(false);
+    BOOST_REQUIRE(r1.has_value() && r2.has_value());
+    BOOST_CHECK(r2->jobId > r1->jobId);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/stratum/test/stratumprotocol_tests.cpp
+++ b/src/stratum/test/stratumprotocol_tests.cpp
@@ -1,0 +1,234 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumprotocol.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumprotocol_tests, BasicTestingSetup)
+
+// --- StratumLineBuffer tests ---
+
+BOOST_AUTO_TEST_CASE(linebuffer_empty) {
+    StratumLineBuffer buf;
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK(lines.empty());
+    BOOST_CHECK_EQUAL(buf.Size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_single_complete_line) {
+    StratumLineBuffer buf;
+    std::string data = "{\"id\":1}\n";
+    buf.Append(data.c_str(), data.size());
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK_EQUAL(lines.size(), 1u);
+    BOOST_CHECK_EQUAL(lines[0], "{\"id\":1}");
+    BOOST_CHECK_EQUAL(buf.Size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_partial_then_complete) {
+    StratumLineBuffer buf;
+    std::string part1 = "{\"id\"";
+    std::string part2 = ":1}\n";
+    buf.Append(part1.c_str(), part1.size());
+    auto lines1 = buf.ExtractLines();
+    BOOST_CHECK(lines1.empty());
+
+    buf.Append(part2.c_str(), part2.size());
+    auto lines2 = buf.ExtractLines();
+    BOOST_CHECK_EQUAL(lines2.size(), 1u);
+    BOOST_CHECK_EQUAL(lines2[0], "{\"id\":1}");
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_multiple_lines_single_chunk) {
+    StratumLineBuffer buf;
+    std::string data = "aaa\nbbb\nccc\n";
+    buf.Append(data.c_str(), data.size());
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK_EQUAL(lines.size(), 3u);
+    BOOST_CHECK_EQUAL(lines[0], "aaa");
+    BOOST_CHECK_EQUAL(lines[1], "bbb");
+    BOOST_CHECK_EQUAL(lines[2], "ccc");
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_no_trailing_newline) {
+    StratumLineBuffer buf;
+    std::string data = "partial";
+    buf.Append(data.c_str(), data.size());
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK(lines.empty());
+    BOOST_CHECK_EQUAL(buf.Size(), 7u);
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_empty_lines_filtered) {
+    StratumLineBuffer buf;
+    std::string data = "\n\n\n";
+    buf.Append(data.c_str(), data.size());
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK(lines.empty());
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_crlf_handling) {
+    StratumLineBuffer buf;
+    std::string data = "hello\r\n";
+    buf.Append(data.c_str(), data.size());
+    auto lines = buf.ExtractLines();
+    BOOST_CHECK_EQUAL(lines.size(), 1u);
+    BOOST_CHECK_EQUAL(lines[0], "hello");
+}
+
+BOOST_AUTO_TEST_CASE(linebuffer_overflow_detection) {
+    StratumLineBuffer buf;
+    // Create a line that's too long
+    std::string longLine(MAX_LINE_LENGTH + 100, 'x');
+    longLine += "\n";
+    buf.Append(longLine.c_str(), longLine.size());
+    buf.ExtractLines();
+    BOOST_CHECK(buf.OverflowDetected());
+}
+
+// --- ParseStratumLine tests ---
+
+BOOST_AUTO_TEST_CASE(parse_subscribe_request) {
+    std::string line =
+        R"({"id":1,"method":"mining.subscribe","params":["test/1.0"]})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *req = std::get_if<StratumRequest>(&*result);
+    BOOST_REQUIRE(req != nullptr);
+    BOOST_CHECK_EQUAL(req->id, 1);
+    BOOST_CHECK_EQUAL(req->method, "mining.subscribe");
+    BOOST_CHECK(req->params.isArray());
+    BOOST_CHECK_EQUAL(req->params.size(), 1u);
+}
+
+BOOST_AUTO_TEST_CASE(parse_authorize_request) {
+    std::string line =
+        R"({"id":2,"method":"mining.authorize","params":["user.worker","pass"]})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *req = std::get_if<StratumRequest>(&*result);
+    BOOST_REQUIRE(req != nullptr);
+    BOOST_CHECK_EQUAL(req->id, 2);
+    BOOST_CHECK_EQUAL(req->method, "mining.authorize");
+    BOOST_CHECK_EQUAL(req->params[0].get_str(), "user.worker");
+    BOOST_CHECK_EQUAL(req->params[1].get_str(), "pass");
+}
+
+BOOST_AUTO_TEST_CASE(parse_submit_request) {
+    std::string line =
+        R"({"id":3,"method":"mining.submit","params":["worker","1a","00000000","5f3c2e1a","deadbeef"]})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *req = std::get_if<StratumRequest>(&*result);
+    BOOST_REQUIRE(req != nullptr);
+    BOOST_CHECK_EQUAL(req->id, 3);
+    BOOST_CHECK_EQUAL(req->method, "mining.submit");
+    BOOST_CHECK_EQUAL(req->params.size(), 5u);
+}
+
+BOOST_AUTO_TEST_CASE(parse_response_success) {
+    std::string line = R"({"id":1,"result":true,"error":null})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *resp = std::get_if<StratumResponse>(&*result);
+    BOOST_REQUIRE(resp != nullptr);
+    BOOST_CHECK_EQUAL(resp->id, 1);
+    BOOST_CHECK(resp->result.get_bool());
+    BOOST_CHECK(resp->error.isNull());
+}
+
+BOOST_AUTO_TEST_CASE(parse_response_error) {
+    std::string line =
+        R"({"id":1,"result":null,"error":[21,"Job not found",null]})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *resp = std::get_if<StratumResponse>(&*result);
+    BOOST_REQUIRE(resp != nullptr);
+    BOOST_CHECK(resp->result.isNull());
+    BOOST_CHECK(resp->error.isArray());
+}
+
+BOOST_AUTO_TEST_CASE(parse_notification) {
+    std::string line =
+        R"({"method":"mining.set_difficulty","params":[1.5]})";
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *notif = std::get_if<StratumNotification>(&*result);
+    BOOST_REQUIRE(notif != nullptr);
+    BOOST_CHECK_EQUAL(notif->method, "mining.set_difficulty");
+}
+
+BOOST_AUTO_TEST_CASE(parse_invalid_json) {
+    auto result = ParseStratumLine("not json at all");
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(parse_missing_method) {
+    auto result = ParseStratumLine(R"({"id":1})");
+    BOOST_CHECK(!result.has_value());
+}
+
+// --- Serialization roundtrip tests ---
+
+BOOST_AUTO_TEST_CASE(serialize_notify_roundtrip) {
+    UniValue params(UniValue::VARR);
+    params.push_back(1.5);
+    std::string serialized = SerializeNotify("mining.set_difficulty", params);
+
+    // Must end with newline
+    BOOST_CHECK_EQUAL(serialized.back(), '\n');
+
+    // Parse back
+    std::string line = serialized.substr(0, serialized.size() - 1);
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *notif = std::get_if<StratumNotification>(&*result);
+    BOOST_REQUIRE(notif != nullptr);
+    BOOST_CHECK_EQUAL(notif->method, "mining.set_difficulty");
+}
+
+BOOST_AUTO_TEST_CASE(serialize_response_roundtrip) {
+    std::string serialized =
+        SerializeResponse(42, UniValue(true), UniValue(UniValue::VNULL));
+    BOOST_CHECK_EQUAL(serialized.back(), '\n');
+
+    std::string line = serialized.substr(0, serialized.size() - 1);
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *resp = std::get_if<StratumResponse>(&*result);
+    BOOST_REQUIRE(resp != nullptr);
+    BOOST_CHECK_EQUAL(resp->id, 42);
+    BOOST_CHECK(resp->result.get_bool());
+}
+
+BOOST_AUTO_TEST_CASE(serialize_request_roundtrip) {
+    UniValue params(UniValue::VARR);
+    params.push_back("test");
+    std::string serialized = SerializeRequest(7, "mining.authorize", params);
+    BOOST_CHECK_EQUAL(serialized.back(), '\n');
+
+    std::string line = serialized.substr(0, serialized.size() - 1);
+    auto result = ParseStratumLine(line);
+    BOOST_CHECK(result.has_value());
+
+    auto *req = std::get_if<StratumRequest>(&*result);
+    BOOST_REQUIRE(req != nullptr);
+    BOOST_CHECK_EQUAL(req->id, 7);
+    BOOST_CHECK_EQUAL(req->method, "mining.authorize");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/stratum/test/stratumstats_tests.cpp
+++ b/src/stratum/test/stratumstats_tests.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumstats.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumstats_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(stats_initial_zeroes) {
+    StratumServerStats stats;
+    BOOST_CHECK_EQUAL(stats.totalConnections, 0u);
+    BOOST_CHECK_EQUAL(stats.activeWorkers, 0u);
+    BOOST_CHECK_EQUAL(stats.totalSharesAccepted, 0u);
+    BOOST_CHECK_EQUAL(stats.totalSharesRejected, 0u);
+    BOOST_CHECK_EQUAL(stats.totalSharesStale, 0u);
+    BOOST_CHECK_EQUAL(stats.blocksFound, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(stats_json_format) {
+    StratumServerStats stats;
+    stats.startTime = 1000;
+    stats.totalConnections = 42;
+    stats.activeWorkers = 5;
+    stats.totalSharesAccepted = 100;
+    stats.totalSharesRejected = 3;
+    stats.blocksFound = 1;
+    stats.networkDifficulty = 12345.6;
+    stats.chainHeight = 500;
+
+    StratumWorker::Stats ws;
+    ws.workerName = "miner.1";
+    ws.currentDifficulty = 1.5;
+    ws.sharesAccepted = 50;
+    ws.sharesRejected = 1;
+    ws.estimatedHashrate = 1000000;
+    ws.state = StratumWorker::State::AUTHORIZED;
+    stats.workers.push_back(ws);
+
+    UniValue json = FormatStatsJson(stats);
+
+    BOOST_CHECK(json.isObject());
+    BOOST_CHECK(json.exists("uptime"));
+    BOOST_CHECK(json.exists("totalConnections"));
+    BOOST_CHECK(json.exists("activeWorkers"));
+    BOOST_CHECK(json.exists("totalSharesAccepted"));
+    BOOST_CHECK(json.exists("totalSharesRejected"));
+    BOOST_CHECK(json.exists("blocksFound"));
+    BOOST_CHECK(json.exists("networkDifficulty"));
+    BOOST_CHECK(json.exists("chainHeight"));
+    BOOST_CHECK(json.exists("workers"));
+
+    BOOST_CHECK_EQUAL(json["totalConnections"].getInt<uint64_t>(), 42u);
+    BOOST_CHECK_EQUAL(json["activeWorkers"].getInt<uint32_t>(), 5u);
+
+    const UniValue &workers = json["workers"];
+    BOOST_CHECK(workers.isArray());
+    BOOST_CHECK_EQUAL(workers.size(), 1u);
+    BOOST_CHECK_EQUAL(workers[0]["name"].get_str(), "miner.1");
+    BOOST_CHECK_EQUAL(workers[0]["state"].get_str(), "authorized");
+}
+
+BOOST_AUTO_TEST_CASE(stats_empty_workers) {
+    StratumServerStats stats;
+    UniValue json = FormatStatsJson(stats);
+    BOOST_CHECK(json["workers"].isArray());
+    BOOST_CHECK_EQUAL(json["workers"].size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(stats_worker_states) {
+    StratumServerStats stats;
+
+    StratumWorker::Stats w1;
+    w1.state = StratumWorker::State::CONNECTED;
+    w1.workerName = "w1";
+    stats.workers.push_back(w1);
+
+    StratumWorker::Stats w2;
+    w2.state = StratumWorker::State::SUBSCRIBED;
+    w2.workerName = "w2";
+    stats.workers.push_back(w2);
+
+    StratumWorker::Stats w3;
+    w3.state = StratumWorker::State::MINING;
+    w3.workerName = "w3";
+    stats.workers.push_back(w3);
+
+    UniValue json = FormatStatsJson(stats);
+    const UniValue &workers = json["workers"];
+    BOOST_CHECK_EQUAL(workers[0]["state"].get_str(), "connected");
+    BOOST_CHECK_EQUAL(workers[1]["state"].get_str(), "subscribed");
+    BOOST_CHECK_EQUAL(workers[2]["state"].get_str(), "mining");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/stratum/test/stratumsubmit_tests.cpp
+++ b/src/stratum/test/stratumsubmit_tests.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumsubmit.h>
+
+#include <arith_uint256.h>
+#include <crypto/scrypt.h>
+#include <primitives/auxpow.h>
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <set>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumsubmit_tests, TestChain100Setup)
+
+BOOST_AUTO_TEST_CASE(parse_submit_valid) {
+    UniValue params(UniValue::VARR);
+    params.push_back("worker.1");
+    params.push_back("1a");
+    params.push_back("00000000");
+    params.push_back("5f3c2e1a");
+    params.push_back("deadbeef");
+
+    auto result = ParseSubmitParams(params);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK_EQUAL(result->workerName, "worker.1");
+    BOOST_CHECK_EQUAL(result->jobId, 0x1a);
+    BOOST_CHECK_EQUAL(result->extranonce2, "00000000");
+    BOOST_CHECK_EQUAL(result->ntime, "5f3c2e1a");
+    BOOST_CHECK_EQUAL(result->nonce, "deadbeef");
+}
+
+BOOST_AUTO_TEST_CASE(parse_submit_missing_fields) {
+    UniValue params(UniValue::VARR);
+    params.push_back("worker");
+    params.push_back("1");
+
+    auto result = ParseSubmitParams(params);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(parse_submit_invalid_hex) {
+    UniValue params(UniValue::VARR);
+    params.push_back("worker");
+    params.push_back("1");
+    params.push_back("00000000");
+    params.push_back("5f3c2e1a");
+    params.push_back("ZZZZZZZZ"); // not hex
+
+    auto result = ParseSubmitParams(params);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(parse_submit_wrong_extranonce2_length) {
+    UniValue params(UniValue::VARR);
+    params.push_back("worker");
+    params.push_back("1");
+    params.push_back("0000");      // too short, expected 8 chars
+    params.push_back("5f3c2e1a");
+    params.push_back("deadbeef");
+
+    auto result = ParseSubmitParams(params);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(difficulty_to_target_one) {
+    arith_uint256 target = DifficultyToTarget(1.0);
+    arith_uint256 diff1;
+    diff1.SetCompact(0x1d00ffff);
+    BOOST_CHECK(target == diff1);
+}
+
+BOOST_AUTO_TEST_CASE(difficulty_to_target_high) {
+    arith_uint256 target1 = DifficultyToTarget(1.0);
+    arith_uint256 target1024 = DifficultyToTarget(1024.0);
+    // Higher difficulty → lower target
+    BOOST_CHECK(target1024 < target1);
+    // Approximately 1024x smaller
+    arith_uint256 ratio = target1 / target1024;
+    BOOST_CHECK(ratio >= 1000 && ratio <= 1048);
+}
+
+BOOST_AUTO_TEST_CASE(scrypt_pow_hash_differs_from_sha256) {
+    CBaseBlockHeader header;
+    header.nVersion = 0x00620004;
+    header.hashPrevBlock = BlockHash();
+    header.hashMerkleRoot.SetNull();
+    header.nTime = 1234567890;
+    header.nBits = 0x1d00ffff;
+    header.nNonce = 42;
+
+    BlockHash powHash = ScryptPowHash(header);
+    BlockHash sha256Hash = header.GetHash();
+
+    // Scrypt PoW hash must differ from SHA-256d block hash
+    BOOST_CHECK(powHash != sha256Hash);
+}
+
+BOOST_AUTO_TEST_CASE(validate_share_rejected_duplicate) {
+    // Create a job from the test chain
+    CScript scriptPubKey = CScript() << OP_TRUE;
+    StratumJobManager mgr(m_node.chainman->ActiveChainstate(),
+                          m_node.mempool.get(),
+                          m_node.chainman->GetParams(),
+                          scriptPubKey, 4, 4);
+
+    auto jobResult = mgr.CreateJob(true);
+    BOOST_REQUIRE(jobResult.has_value());
+
+    ShareSubmission sub;
+    sub.workerName = "test";
+    sub.jobId = jobResult->jobId;
+    sub.extranonce2 = "00000000";
+    sub.ntime = jobResult->ntime;
+    sub.nonce = "deadbeef";
+
+    std::set<std::string> nonces;
+    const auto &consensus = m_node.chainman->GetParams().GetConsensus();
+
+    // First submission (will be low diff but not duplicate)
+    ValidateShare(*jobResult, "00000001", sub, 0.001, consensus, nonces);
+
+    // Same nonce again → duplicate
+    ShareResult result =
+        ValidateShare(*jobResult, "00000001", sub, 0.001, consensus, nonces);
+    BOOST_CHECK(result == ShareResult::REJECTED_DUPLICATE);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/stratum/test/stratumworker_tests.cpp
+++ b/src/stratum/test/stratumworker_tests.cpp
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 Tobias Ruck and Alexandre Guillioud
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stratum/stratumworker.h>
+
+#include <test/util/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <set>
+
+using namespace stratum;
+
+BOOST_FIXTURE_TEST_SUITE(stratumworker_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(initial_state_connected) {
+    StratumWorker worker(1, "00000001", 1.0);
+    BOOST_CHECK(worker.GetState() == StratumWorker::State::CONNECTED);
+    BOOST_CHECK_EQUAL(worker.GetSessionId(), 1u);
+    BOOST_CHECK_EQUAL(worker.GetExtranonce1(), "00000001");
+}
+
+BOOST_AUTO_TEST_CASE(subscribe_transitions_to_subscribed) {
+    StratumWorker worker(1, "abcd1234", 1.0);
+    UniValue params(UniValue::VARR);
+    params.push_back("test/1.0");
+
+    auto result = worker.HandleSubscribe(params);
+    BOOST_CHECK(result.has_value());
+    BOOST_CHECK(worker.GetState() == StratumWorker::State::SUBSCRIBED);
+}
+
+BOOST_AUTO_TEST_CASE(subscribe_returns_extranonce) {
+    StratumWorker worker(1, "abcd1234", 1.0);
+    UniValue params(UniValue::VARR);
+    auto result = worker.HandleSubscribe(params);
+    BOOST_REQUIRE(result.has_value());
+
+    // Result should be [subscriptions, extranonce1, extranonce2_size]
+    BOOST_CHECK(result->isArray());
+    BOOST_CHECK_EQUAL(result->size(), 3u);
+    BOOST_CHECK_EQUAL((*result)[1].get_str(), "abcd1234");
+    BOOST_CHECK_EQUAL((*result)[2].getInt<int>(),
+                      (int)StratumWorker::EXTRANONCE2_SIZE);
+}
+
+BOOST_AUTO_TEST_CASE(authorize_requires_subscribed) {
+    StratumWorker worker(1, "00000001", 1.0);
+    UniValue params(UniValue::VARR);
+    params.push_back("worker.1");
+    params.push_back("pass");
+
+    auto result = worker.HandleAuthorize(params);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(authorize_sets_worker_name) {
+    StratumWorker worker(1, "00000001", 1.0);
+
+    UniValue subParams(UniValue::VARR);
+    worker.HandleSubscribe(subParams);
+
+    UniValue authParams(UniValue::VARR);
+    authParams.push_back("worker.1");
+    authParams.push_back("x");
+    auto result = worker.HandleAuthorize(authParams);
+
+    BOOST_CHECK(result.has_value());
+    BOOST_CHECK_EQUAL(worker.GetWorkerName(), "worker.1");
+}
+
+BOOST_AUTO_TEST_CASE(authorize_transitions_to_authorized) {
+    StratumWorker worker(1, "00000001", 1.0);
+
+    UniValue subParams(UniValue::VARR);
+    worker.HandleSubscribe(subParams);
+
+    UniValue authParams(UniValue::VARR);
+    authParams.push_back("user");
+    worker.HandleAuthorize(authParams);
+
+    BOOST_CHECK(worker.GetState() == StratumWorker::State::AUTHORIZED);
+}
+
+BOOST_AUTO_TEST_CASE(double_subscribe_rejected) {
+    StratumWorker worker(1, "00000001", 1.0);
+    UniValue params(UniValue::VARR);
+
+    auto r1 = worker.HandleSubscribe(params);
+    BOOST_CHECK(r1.has_value());
+
+    auto r2 = worker.HandleSubscribe(params);
+    BOOST_CHECK(!r2.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(share_accepted_updates_stats) {
+    StratumWorker worker(1, "00000001", 1.0);
+    worker.RecordShareAccepted(1.0);
+    auto stats = worker.GetStats();
+    BOOST_CHECK_EQUAL(stats.sharesAccepted, 1u);
+    BOOST_CHECK_EQUAL(stats.sharesRejected, 0u);
+}
+
+BOOST_AUTO_TEST_CASE(share_rejected_updates_stats) {
+    StratumWorker worker(1, "00000001", 1.0);
+    worker.RecordShareRejected();
+    auto stats = worker.GetStats();
+    BOOST_CHECK_EQUAL(stats.sharesRejected, 1u);
+}
+
+BOOST_AUTO_TEST_CASE(share_stale_updates_stats) {
+    StratumWorker worker(1, "00000001", 1.0);
+    worker.RecordShareStale();
+    auto stats = worker.GetStats();
+    BOOST_CHECK_EQUAL(stats.sharesStale, 1u);
+}
+
+BOOST_AUTO_TEST_CASE(timeout_detection) {
+    StratumWorker worker(1, "00000001", 1.0);
+    int64_t now = GetTime();
+    worker.Touch(now - 400);
+    BOOST_CHECK(worker.IsTimedOut(300, now));
+}
+
+BOOST_AUTO_TEST_CASE(timeout_not_reached) {
+    StratumWorker worker(1, "00000001", 1.0);
+    int64_t now = GetTime();
+    worker.Touch(now);
+    BOOST_CHECK(!worker.IsTimedOut(300, now));
+}
+
+BOOST_AUTO_TEST_CASE(difficulty_bounded) {
+    StratumWorker worker(1, "00000001", 1.0);
+    worker.SetDifficulty(0.0000001);
+    BOOST_CHECK(worker.GetCurrentDifficulty() >= MIN_DIFFICULTY);
+
+    worker.SetDifficulty(1e15);
+    BOOST_CHECK(worker.GetCurrentDifficulty() <= MAX_DIFFICULTY);
+}
+
+BOOST_AUTO_TEST_CASE(vardiff_initial_no_retarget) {
+    StratumWorker worker(1, "00000001", 1.0);
+    StratumConfig config;
+    config.useVarDiff = true;
+    config.varDiffRetargetTime = 90;
+
+    // No shares yet
+    BOOST_CHECK(!worker.ShouldRetargetDifficulty(config, GetTime() + 200));
+}
+
+// --- ExtranonceMgr tests ---
+
+BOOST_AUTO_TEST_CASE(extranonce_mgr_unique) {
+    ExtranonceMgr mgr;
+    std::set<std::string> seen;
+    for (int i = 0; i < 1000; i++) {
+        std::string en = mgr.Next();
+        BOOST_CHECK(seen.insert(en).second);
+    }
+    BOOST_CHECK_EQUAL(seen.size(), 1000u);
+}
+
+BOOST_AUTO_TEST_CASE(extranonce_mgr_format) {
+    ExtranonceMgr mgr;
+    std::string en = mgr.Next();
+    BOOST_CHECK_EQUAL(en.size(), 8u);
+    // Must be valid hex
+    for (char c : en) {
+        BOOST_CHECK(
+            (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(extranonce2_size_constant) {
+    BOOST_CHECK_EQUAL(StratumWorker::EXTRANONCE2_SIZE, 4u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/stratum_basic.py
+++ b/test/functional/stratum_basic.py
@@ -9,7 +9,6 @@ receive jobs, and disconnect.
 
 import json
 import socket
-import time
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -101,8 +100,13 @@ class StratumBasicTest(BitcoinTestFramework):
         # Generate some blocks so the chain is active
         self.generatetoaddress(node, 110, node.get_deterministic_priv_key().address)
 
-        # Give stratum server time to start
-        time.sleep(1)
+        # Wait for stratum server to be ready
+        self.wait_until(
+            lambda: node.debug_log_path.read_text(
+                encoding="utf-8", errors="replace"
+            ).find("Stratum: server started") != -1,
+            timeout=10,
+        )
 
         self.log.info("Test: TCP connection to Stratum server")
         sock = self.stratum_connect()

--- a/test/functional/stratum_basic.py
+++ b/test/functional/stratum_basic.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Tobias Ruck and Alexandre Guillioud
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test basic Stratum server functionality: connect, subscribe, authorize,
+receive jobs, and disconnect.
+"""
+
+import json
+import socket
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+
+class StratumBasicTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            "-stratum",
+            "-stratumport=23333",
+            "-stratumbind=127.0.0.1",
+            "-stratumdifficulty=0.001",
+        ]]
+
+    def stratum_connect(self, port=23333):
+        """Create a TCP connection to the Stratum server."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(10)
+        sock.connect(("127.0.0.1", port))
+        return sock
+
+    def stratum_send(self, sock, msg):
+        """Send a JSON-RPC message over Stratum."""
+        data = json.dumps(msg) + "\n"
+        sock.sendall(data.encode())
+
+    def stratum_recv(self, sock, timeout=5):
+        """Receive and parse JSON-RPC messages from Stratum."""
+        sock.settimeout(timeout)
+        data = b""
+        messages = []
+        try:
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                while b"\n" in data:
+                    line, data = data.split(b"\n", 1)
+                    line = line.strip()
+                    if line:
+                        messages.append(json.loads(line))
+                if messages:
+                    break
+        except socket.timeout:
+            pass
+        return messages
+
+    def stratum_subscribe(self, sock, req_id=1):
+        """Send mining.subscribe and return response."""
+        self.stratum_send(sock, {
+            "id": req_id,
+            "method": "mining.subscribe",
+            "params": ["stratum_basic_test/1.0"],
+        })
+        msgs = self.stratum_recv(sock)
+        for msg in msgs:
+            if msg.get("id") == req_id:
+                return msg
+        return None
+
+    def stratum_authorize(self, sock, worker="test.worker", password="x",
+                          req_id=2):
+        """Send mining.authorize and return response."""
+        self.stratum_send(sock, {
+            "id": req_id,
+            "method": "mining.authorize",
+            "params": [worker, password],
+        })
+        # May receive set_difficulty and notify before auth response
+        msgs = self.stratum_recv(sock, timeout=5)
+        auth_response = None
+        notifications = []
+        for msg in msgs:
+            if msg.get("id") == req_id:
+                auth_response = msg
+            else:
+                notifications.append(msg)
+        # Collect any additional notifications
+        more = self.stratum_recv(sock, timeout=2)
+        notifications.extend(more)
+        return auth_response, notifications
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Generate some blocks so the chain is active
+        self.generatetoaddress(node, 110, node.get_deterministic_priv_key().address)
+
+        # Give stratum server time to start
+        time.sleep(1)
+
+        self.log.info("Test: TCP connection to Stratum server")
+        sock = self.stratum_connect()
+        assert sock is not None
+
+        self.log.info("Test: mining.subscribe")
+        sub_response = self.stratum_subscribe(sock)
+        assert sub_response is not None
+        assert sub_response.get("error") is None
+        result = sub_response["result"]
+        # Result: [[subscriptions], extranonce1, extranonce2_size]
+        assert len(result) == 3
+        extranonce1 = result[1]
+        extranonce2_size = result[2]
+        assert len(extranonce1) == 8  # 4 bytes = 8 hex chars
+        assert extranonce2_size == 4
+
+        self.log.info("Test: mining.authorize")
+        auth_response, notifications = self.stratum_authorize(sock)
+        assert auth_response is not None
+        assert auth_response["result"] is True
+        assert auth_response.get("error") is None
+
+        self.log.info("Test: receive mining.set_difficulty")
+        diff_notifs = [n for n in notifications
+                       if n.get("method") == "mining.set_difficulty"]
+        # Should receive at least one difficulty notification
+        assert len(diff_notifs) >= 1
+        assert diff_notifs[0]["params"][0] > 0
+
+        self.log.info("Test: receive mining.notify")
+        notify_notifs = [n for n in notifications
+                         if n.get("method") == "mining.notify"]
+        if not notify_notifs:
+            # May need to wait a bit more
+            more = self.stratum_recv(sock, timeout=3)
+            notify_notifs = [n for n in more
+                             if n.get("method") == "mining.notify"]
+        assert len(notify_notifs) >= 1
+
+        job_params = notify_notifs[0]["params"]
+        assert len(job_params) == 9
+        job_id = job_params[0]
+        prev_hash = job_params[1]
+        version = job_params[5]
+        nbits = job_params[6]
+        ntime = job_params[7]
+        clean_jobs = job_params[8]
+
+        assert len(prev_hash) == 64
+        assert len(version) == 8
+        assert len(nbits) == 8
+        assert len(ntime) == 8
+        assert isinstance(clean_jobs, bool)
+
+        self.log.info("Test: mining.notify version has chain ID 0x62")
+        # Version is little-endian hex, parse to uint32
+        version_bytes = bytes.fromhex(version)
+        version_int = int.from_bytes(version_bytes, "little")
+        chain_id = (version_int >> 16) & 0xFFFF
+        assert_equal(chain_id, 0x62)
+
+        self.log.info("Test: authorize before subscribe fails")
+        sock2 = self.stratum_connect()
+        self.stratum_send(sock2, {
+            "id": 1,
+            "method": "mining.authorize",
+            "params": ["user", "pass"],
+        })
+        msgs = self.stratum_recv(sock2)
+        auth_msg = None
+        for msg in msgs:
+            if msg.get("id") == 1:
+                auth_msg = msg
+        assert auth_msg is not None
+        assert auth_msg.get("error") is not None
+        sock2.close()
+
+        self.log.info("Test: multiple concurrent connections get unique extranonce1")
+        sock3 = self.stratum_connect()
+        sub3 = self.stratum_subscribe(sock3, req_id=10)
+        assert sub3 is not None
+        extranonce1_2 = sub3["result"][1]
+        assert extranonce1 != extranonce1_2
+
+        sock.close()
+        sock3.close()
+
+        self.log.info("All Stratum basic tests passed!")
+
+
+if __name__ == "__main__":
+    StratumBasicTest().main()


### PR DESCRIPTION
## Summary

Embedded Stratum v1 mining server for doged, enabling pool-less solo mining directly from the node.

This is the foundational PR — later PRs will add upstream proxy routing, AuxPoW merge-mining RPCs, and multi-chain support on top.

### What's included

| Layer | Files | Description |
|-------|-------|-------------|
| **Protocol** | `stratumprotocol.{h,cpp}` | Stratum JSON-RPC message types, line-buffered parser, serializers |
| **Config** | `stratumconfig.{h,cpp}` | `-stratum`, `-stratumbind`, `-stratumport`, `-stratumpassword`, `-stratumdiff`, `-coinbaseaddr` CLI args |
| **Worker** | `stratumworker.{h,cpp}` | Per-connection session state machine: subscribe → authorize → mining, variable difficulty retarget |
| **Job** | `stratumjob.{h,cpp}` | Job manager: polls `getblocktemplate`, splits coinbase for extranonce, builds merkle branches |
| **Submit** | `stratumsubmit.{h,cpp}` | Share validation via scrypt PoW hash, duplicate detection, difficulty check |
| **Stats** | `stratumstats.{h,cpp}` | Connection count, hashrate estimate, accepted/rejected share counters, JSON formatter |
| **Server** | `stratum.{h,cpp}` | libevent TCP listener, accept/read/dispatch loop, thread-safe worker management |
| **Lifecycle** | `init.cpp` | Start/stop stratum in the node init sequence (after chainstate is loaded) |
| **Logging** | `logging.{h,cpp}` | `BCLog::STRATUM` category |
| **Build** | `CMakeLists.txt` | Compile stratum modules into libserver, wire Boost unit test suite |
| **Unit tests** | `src/stratum/test/*.cpp` | Protocol parsing, config edge cases, worker lifecycle, job creation, share validation, stats output |
| **Functional test** | `stratum_basic.py` | End-to-end: start node with `-stratum=1`, TCP connect, subscribe, authorize |

### Architecture

```
┌─────────────────────────────────┐
│           doged node            │
│  ┌───────────────────────────┐  │
│  │     StratumServer         │  │
│  │  libevent TCP :9334       │  │
│  │  ┌─────────────────────┐  │  │
│  │  │  StratumWorker[]    │  │  │
│  │  │  subscribe/auth/    │  │  │
│  │  │  vardiff/sessions   │  │  │
│  │  └────────┬────────────┘  │  │
│  │           │               │  │
│  │  ┌────────▼────────────┐  │  │
│  │  │  StratumJobManager  │  │  │
│  │  │  getblocktemplate   │  │  │
│  │  │  coinbase split     │  │  │
│  │  │  merkle branches    │  │  │
│  │  └────────┬────────────┘  │  │
│  │           │               │  │
│  │  ┌────────▼────────────┐  │  │
│  │  │  ValidateShare()    │  │  │
│  │  │  scrypt PoW check   │  │  │
│  │  │  submitblock on hit │  │  │
│  │  └─────────────────────┘  │  │
│  └───────────────────────────┘  │
└─────────────────────────────────┘
```

### Usage

```bash
doged -stratum=1 -stratumport=9334 -coinbaseaddr=DYourDogeAddress
```

### Follow-up PRs (stacked)

- **PR2**: Upstream proxy connector + tiered routing (local → proxy → failover)
- **PR3**: AuxPoW merge-mining RPCs (`createauxblock`, `submitauxblock`)
- **PR4**: Multi-chain merge-mine manager with pluggable `IAuxChainModule`
- **PR5**: Independent per-chain target checking + AuxPoW proof construction

## Test plan

- [ ] `ninja check-stratum` — 6 Boost unit test suites pass
- [ ] `test/functional/stratum_basic.py` — e2e subscribe + authorize
- [ ] Manual: start doged with `-stratum=1`, connect with any Stratum v1 miner, verify jobs received
- [ ] Verify no regressions: `ninja check` on existing test suites